### PR TITLE
docs(workflow): reserve pull request merges for the owner

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr
-description: Pushes the current branch and opens a PR toward the correct target. Extracts the issue number from the branch name automatically.
-allowed-tools: Bash, mcp__github__create_pull_request
+description: Pushes the current branch and opens a fully configured PR toward the correct target. Never merges it.
+allowed-tools: Bash
 ---
 
 The user wants to push their current branch and open a PR.
@@ -64,12 +64,17 @@ Execute in order:
    - Add `domain: devops` if files changed in `.github/`
    - Add `domain: shared` if files changed in `packages/`
 
-8. **Create the PR via mcp**github**create_pull_request**
+8. **Create the PR with `gh pr create`**
    - owner and repo read from MEMORY.md
-   - assignees: [owner]
-   - reviewers: [owner]
+   - assign the PR to the owner
+   - never assign the owner as their own reviewer
+   - never merge the PR, even after CI passes
 
-9. **Assign the PR to the Scrum Board and milestone** (if PROJECT_ID is set in MEMORY.md)
+9. **Assign the PR to the Scrum Board and milestone — mandatory**
+
+   - Reuse the linked issue milestone when available; otherwise select the milestone matching the phase or release.
+   - Resolve the repository project with `gh project list --owner <owner>` when `PROJECT_ID` is not recorded in MEMORY.md.
+   - If the CLI lacks `read:project` or `project` scope, stop and ask the user to authorize the required scope. Never skip the project silently.
 
    ```bash
    PR_NODE_ID=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER> --jq '.node_id')
@@ -79,5 +84,12 @@ Execute in order:
    gh api repos/<owner>/<repo>/issues/<PR_NUMBER> --method PATCH --field milestone=$MILESTONE_NUMBER
    ```
 
-10. **Confirm to the user with the PR URL**
-    - Show: assignee ✅, reviewer ✅, project ✅, milestone ✅ (or "no milestone for this branch")
+10. **Apply and verify all metadata**
+    - Add applicable type, domain, priority, and phase labels.
+    - Verify issue link, assignee, labels, milestone, project, title, body, and CI status with `gh`.
+    - Missing required metadata is a blocker, not a warning.
+
+11. **Confirm to the user with the PR URL, then stop**
+    - Show: issue ✅, assignee ✅, labels ✅, project ✅, milestone ✅, CI status.
+    - Explicitly state that the PR is waiting for Adem's manual merge.
+    - Do not close the linked issue manually before the merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ These rules extend `~/.codex/AGENTS.md` and apply to this repository.
 
 ## Required Pull Request Metadata
 
+Repository project: `AdamDjo` → `Scrum Board` (`#5`).
+
 Before reporting a pull request as ready, verify all of the following with the GitHub CLI:
 
 - linked issue through `Closes #<number>`;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# PortfolioAI — Local Agent Rules
+
+These rules extend `~/.codex/AGENTS.md` and apply to this repository.
+
+## GitHub Delivery
+
+- Adem is the only person allowed to merge pull requests.
+- Agents must never run `gh pr merge`, call a GitHub merge API, merge a feature branch into `develop` or `main`, or close the linked issue as completed before Adem merges.
+- Feature, fix, and chore pull requests target `develop`.
+- Hotfix and release pull requests target `main`.
+- The agent may monitor CI, report failures, and push fixes to the PR branch, but must stop once the PR is ready for manual review.
+
+## Required Pull Request Metadata
+
+Before reporting a pull request as ready, verify all of the following with the GitHub CLI:
+
+- linked issue through `Closes #<number>`;
+- assignee: `AdamDjo`;
+- applicable type, domain, priority, and phase labels;
+- milestone matching the issue phase or release;
+- pull request added to the repository GitHub Project;
+- complete title, summary, test plan, and validation results;
+- CI status reported without merging.
+
+If GitHub CLI lacks the `read:project` or `project` scopes, or if no project or milestone can be resolved, stop and tell Adem exactly which permission or choice is missing. Never silently omit required metadata.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,21 @@ release/<semver>
 
 - Always create the issue before the branch
 - Never commit directly to `develop` or `main`
+- Never merge a pull request: Adem always performs merges manually
+- Never run `gh pr merge`, call a GitHub merge API, merge locally into `develop` or `main`, or close the linked issue before Adem merges
 - Use `/feature`, `/bug`, `/hotfix` skills — they create issue + branch automatically
+
+**Required PR delivery checklist:**
+
+- Link the issue with `Closes #<number>`
+- Assign the PR to `AdamDjo`
+- Add all applicable type, domain, priority, and phase labels
+- Assign the matching milestone
+- Add the PR to the repository GitHub Project
+- Include a complete summary, test plan, and validation results
+- Verify every metadata field with the GitHub CLI after PR creation
+- CI may be monitored and fixes may be pushed to the PR branch, but the workflow always stops before merge
+- If a required permission, milestone, or GitHub Project is unavailable, report the blocker instead of silently omitting it
 
 ### Workflow Claude → GitHub
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -3,6 +3,8 @@
 ## Repository
 
 - GitHub : `AdamDjo/PortfolioAI`
+- GitHub Project : `Scrum Board` (`AdamDjo`, projet #5)
+- Project ID : `PVT_kwHOAacnj84BU6rS`
 - Visibilité : publique
 - Branches d'intégration : `main` et `develop`
 


### PR DESCRIPTION
## Summary
- forbid Codex and Claude agents from merging pull requests
- require every PR to include its issue, assignee, labels, milestone, GitHub Project, summary, test plan, and CI status
- make missing GitHub metadata a blocking condition instead of a silent omission
- record the repository Scrum Board identifier for future workflows

## Test plan
- [x] Prettier validation passes
- [x] Markdown diff contains no whitespace errors
- [x] GitHub Project scopes and Scrum Board access verified

## Delivery rule
This PR must be merged manually by Adem. Agents stop after preparing and verifying it.

Closes #17