### PR TITLE
feat(frontend): serve veille links from Payload with owner-only writes

### DIFF
--- a/apps/frontend/src/app/(site)/veille/page.tsx
+++ b/apps/frontend/src/app/(site)/veille/page.tsx
@@ -1,151 +1,35 @@
-'use client'
+import { headers } from 'next/headers'
+import { getPayload } from 'payload'
 
-import { Link2, Plus, X } from 'lucide-react'
-import { AnimatePresence, m } from 'motion/react'
-import Image from 'next/image'
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { BookmarkComposer } from '@/components/veille/bookmark-composer'
+import { BookmarkGrid } from '@/components/veille/bookmark-grid'
+import { listPublicBookmarks } from '@/lib/bookmarks'
+import config from '@payload-config'
 
-import { EASE_OUT_QUINT } from '@/components/motion/primitives'
+import type { Metadata } from 'next'
 
-interface Bookmark {
-  id: string
-  url: string
-  domain: string
-  name: string
-  tags: string[]
+export const metadata: Metadata = {
+  title: 'Veille',
+  description: 'Ma bibliothèque de liens techniques, triée par tags.',
 }
 
-const STORAGE_KEY = 'adem-veille-bookmarks'
-const DEFAULT_TAG = 'À trier'
-const COVER_TONES = ['violet', 'coral', 'blue', 'green', 'cyan', 'mono'] as const
+/**
+ * La liste change dès qu'un lien est ajouté : on rend à la demande plutôt que de
+ * figer la page au build.
+ */
+export const dynamic = 'force-dynamic'
 
-const seedBookmarks: Bookmark[] = [
-  {
-    id: 'react-dev',
-    url: 'https://react.dev',
-    domain: 'react.dev',
-    name: 'React',
-    tags: ['React'],
-  },
-  {
-    id: 'nextjs-org',
-    url: 'https://nextjs.org',
-    domain: 'nextjs.org',
-    name: 'Next.js',
-    tags: ['Next.js'],
-  },
-  {
-    id: 'motion-dev',
-    url: 'https://motion.dev',
-    domain: 'motion.dev',
-    name: 'Motion',
-    tags: ['Animation'],
-  },
-  {
-    id: 'web-dev',
-    url: 'https://web.dev',
-    domain: 'web.dev',
-    name: 'web.dev',
-    tags: ['Performance'],
-  },
-  {
-    id: 'tailwindcss-com',
-    url: 'https://tailwindcss.com',
-    domain: 'tailwindcss.com',
-    name: 'Tailwind CSS',
-    tags: ['CSS'],
-  },
-  {
-    id: 'anthropic-com',
-    url: 'https://www.anthropic.com',
-    domain: 'anthropic.com',
-    name: 'Anthropic',
-    tags: ['IA'],
-  },
-]
-
-function coverTone(domain: string) {
-  let hash = 0
-  for (const char of domain) hash = (hash * 31 + char.codePointAt(0)!) % 997
-  return COVER_TONES[hash % COVER_TONES.length]
+/** Vrai uniquement si la requête porte une session Payload valide. */
+async function isOwner(): Promise<boolean> {
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: await headers() })
+  return Boolean(user)
 }
 
-function parseBookmark(raw: string, activeTag: string): Bookmark | null {
-  const candidate = raw.trim()
-  if (!candidate) return null
-  try {
-    const url = new URL(candidate.includes('://') ? candidate : `https://${candidate}`)
-    if (!url.hostname.includes('.')) return null
-    const domain = url.hostname.replace(/^www\./, '')
-    // Prefer the registrable name over a subdomain: developer.mozilla.org -> Mozilla.
-    const parts = domain.split('.')
-    const label = parts.length > 2 ? parts[parts.length - 2] : parts[0]
-    return {
-      id: `${domain}-${Date.now()}`,
-      url: url.href,
-      domain,
-      name: label.charAt(0).toUpperCase() + label.slice(1),
-      tags: [activeTag === 'Tous' ? DEFAULT_TAG : activeTag],
-    }
-  } catch {
-    return null
-  }
-}
-
-function WatchPage() {
-  const [bookmarks, setBookmarks] = useState<Bookmark[]>(seedBookmarks)
-  const [hydrated, setHydrated] = useState(false)
-  const [draft, setDraft] = useState('')
-  const [activeTag, setActiveTag] = useState('Tous')
-  const [error, setError] = useState(false)
-
-  useEffect(() => {
-    try {
-      const saved = window.localStorage.getItem(STORAGE_KEY)
-      if (saved) setBookmarks(JSON.parse(saved) as Bookmark[])
-    } catch {
-      // Corrupted storage: keep the seeds.
-    }
-    setHydrated(true)
-  }, [])
-
-  useEffect(() => {
-    if (hydrated) window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bookmarks))
-  }, [bookmarks, hydrated])
-
-  const tags = useMemo(() => {
-    const all = new Set<string>()
-    for (const bookmark of bookmarks) for (const tag of bookmark.tags) all.add(tag)
-    return ['Tous', ...[...all].sort((a, b) => a.localeCompare(b, 'fr'))]
-  }, [bookmarks])
-
-  const visibleBookmarks = useMemo(
-    () =>
-      activeTag === 'Tous'
-        ? bookmarks
-        : bookmarks.filter((bookmark) => bookmark.tags.includes(activeTag)),
-    [bookmarks, activeTag]
-  )
-
-  function addBookmark(raw: string) {
-    const bookmark = parseBookmark(raw, activeTag)
-    if (!bookmark) {
-      setError(true)
-      return
-    }
-    setError(false)
-    setDraft('')
-    setBookmarks((current) => [bookmark, ...current])
-  }
-
-  function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    addBookmark(draft)
-  }
-
-  function removeBookmark(id: string) {
-    setBookmarks((current) => current.filter((bookmark) => bookmark.id !== id))
-  }
+async function WatchPage() {
+  // La lecture est publique, la session ne sert qu'à décider d'afficher le
+  // formulaire : les deux requêtes sont indépendantes.
+  const [bookmarks, owner] = await Promise.all([listPublicBookmarks(), isOwner()])
 
   return (
     <div className="page shell">
@@ -153,111 +37,12 @@ function WatchPage() {
         <p className="eyebrow">Veille active</p>
         <h1>Ma bibliothèque de liens, triée par tags.</h1>
         <p>
-          Colle un lien, il devient une carte cliquable. Filtre par tag pour retrouver une référence
-          en quelques secondes.
+          Les références que je garde sous la main, avec leur aperçu. Filtre par tag pour retrouver
+          une ressource en quelques secondes.
         </p>
       </header>
-      <form className="search-bar veille-add-bar" onSubmit={submit}>
-        <Link2 size={17} />
-        <label className="sr-only" htmlFor="veille-url">
-          Ajouter un lien
-        </label>
-        <input
-          id="veille-url"
-          value={draft}
-          onChange={(event) => {
-            setDraft(event.target.value)
-            setError(false)
-          }}
-          onPaste={(event) => {
-            const pasted = event.clipboardData.getData('text')
-            if (parseBookmark(pasted, activeTag)) {
-              event.preventDefault()
-              addBookmark(pasted)
-            }
-          }}
-          placeholder="Collez votre lien ici…"
-          aria-invalid={error}
-        />
-        <button type="submit">
-          <Plus size={14} /> Ajouter
-        </button>
-      </form>
-      <AnimatePresence>
-        {error ? (
-          <m.p
-            className="veille-error"
-            role="alert"
-            initial={{ opacity: 0, y: -6, height: 0 }}
-            animate={{ opacity: 1, y: 0, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.3, ease: EASE_OUT_QUINT }}
-          >
-            Ce lien ne ressemble pas à une URL valide.
-          </m.p>
-        ) : null}
-      </AnimatePresence>
-      <div className="filter-row veille-tags" role="group" aria-label="Filtrer par tag">
-        {tags.map((tag) => (
-          <button
-            className={tag === activeTag ? 'is-active' : undefined}
-            key={tag}
-            onClick={() => setActiveTag(tag)}
-            type="button"
-            aria-pressed={tag === activeTag}
-          >
-            {tag}
-          </button>
-        ))}
-      </div>
-      <div className="veille-grid">
-        <AnimatePresence mode="popLayout" initial={false}>
-          {visibleBookmarks.map((bookmark) => (
-            <m.article
-              className="veille-card"
-              key={bookmark.id}
-              layout
-              initial={{ opacity: 0, scale: 0.9, y: 14 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.9 }}
-              transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
-            >
-              <a href={bookmark.url} target="_blank" rel="noreferrer">
-                <span className={`veille-cover veille-cover-${coverTone(bookmark.domain)}`}>
-                  <Image
-                    // `sz` is a hint: Google returns the closest size it holds, so
-                    // asking for 64 often yields 28px for a 40px slot. Requesting
-                    // 128 covers the 2x display density on high-DPI screens.
-                    src={`https://www.google.com/s2/favicons?domain=${bookmark.domain}&sz=128`}
-                    alt=""
-                    width={40}
-                    height={40}
-                    unoptimized
-                  />
-                </span>
-                <p>{bookmark.domain}</p>
-                <h2>{bookmark.name}</h2>
-                <span className="veille-tag-list">
-                  {bookmark.tags.map((tag) => (
-                    <span key={tag}>{tag}</span>
-                  ))}
-                </span>
-              </a>
-              <button
-                className="veille-remove"
-                onClick={() => removeBookmark(bookmark.id)}
-                type="button"
-                aria-label={`Supprimer ${bookmark.name}`}
-              >
-                <X size={13} />
-              </button>
-            </m.article>
-          ))}
-        </AnimatePresence>
-      </div>
-      {visibleBookmarks.length === 0 ? (
-        <p className="veille-empty">Aucun lien avec ce tag pour l’instant.</p>
-      ) : null}
+      {owner ? <BookmarkComposer /> : null}
+      <BookmarkGrid bookmarks={bookmarks} />
     </div>
   )
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1776,6 +1776,32 @@ img {
   height: 40px;
   border-radius: 8px;
 }
+
+/* Aperçu Open Graph : l'image remplit la vignette, le favicon reste centré. */
+.veille-cover-preview {
+  overflow: hidden;
+  padding: 0;
+  background: var(--bg);
+}
+.veille-cover-preview img {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+  object-fit: cover;
+}
+.veille-spinner {
+  animation: veille-spin 900ms linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .veille-spinner {
+    animation: none;
+  }
+}
+@keyframes veille-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 .veille-card > a > p {
   margin: 0;
   color: var(--muted);

--- a/apps/frontend/src/collections/bookmarks.ts
+++ b/apps/frontend/src/collections/bookmarks.ts
@@ -1,0 +1,116 @@
+import { canonicalizeUrl } from '../lib/canonical-url'
+import { withOpenGraphPreview } from '../lib/open-graph-hook'
+
+import type { CollectionConfig } from 'payload'
+
+/**
+ * Liens de veille.
+ *
+ * Le geste visé est minimal : coller une URL, rien d'autre. Le titre, la
+ * description, l'image d'aperçu et le domaine sont récupérés depuis les balises
+ * Open Graph de la page cible, donc aucun téléversement n'est nécessaire.
+ *
+ * L'écriture est réservée à l'administrateur connecté : les visiteurs consultent
+ * la liste mais ne peuvent pas l'alimenter. C'est délibéré — un formulaire ouvert
+ * serait une porte à spam sur une page publique.
+ */
+const Bookmarks: CollectionConfig = {
+  slug: 'bookmarks',
+  labels: { singular: 'Lien de veille', plural: 'Liens de veille' },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'domain', 'active', 'updatedAt'],
+    description: "Collez l'URL : le reste est récupéré automatiquement.",
+  },
+  access: {
+    read: () => true,
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+    delete: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'url',
+      type: 'text',
+      label: 'URL',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'Normalisée automatiquement : les paramètres de suivi sont retirés.',
+      },
+      validate: (value: string | null | undefined) => {
+        if (typeof value !== 'string' || value.trim() === '') return 'Une URL est requise.'
+        return canonicalizeUrl(value) ? true : 'Cette adresse n’est pas une URL http(s) valide.'
+      },
+    },
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Titre',
+      admin: {
+        description: 'Laissez vide pour reprendre le titre de la page distante.',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Description',
+      admin: {
+        description: 'Laissez vide pour reprendre la description de la page distante.',
+      },
+    },
+    {
+      name: 'domain',
+      type: 'text',
+      label: 'Domaine (automatique)',
+      index: true,
+      admin: {
+        readOnly: true,
+        description: "Déduit de l'URL, utilisé pour l'affichage et le favicon.",
+      },
+    },
+    {
+      name: 'previewImageUrl',
+      type: 'text',
+      label: "Image d'aperçu (automatique)",
+      admin: {
+        readOnly: true,
+        description: "Extraite des balises Open Graph à chaque modification de l'URL.",
+      },
+    },
+    {
+      name: 'tags',
+      type: 'relationship',
+      relationTo: 'tags',
+      hasMany: true,
+      label: 'Tags',
+      admin: {
+        description: 'Sert aux filtres de la page Veille.',
+      },
+    },
+    {
+      name: 'active',
+      type: 'checkbox',
+      label: 'Visible sur le site',
+      defaultValue: true,
+      index: true,
+      admin: {
+        description: 'Décochez pour retirer le lien du site sans le supprimer.',
+      },
+    },
+  ],
+  hooks: {
+    beforeChange: [
+      withOpenGraphPreview({
+        url: 'url',
+        title: 'title',
+        description: 'description',
+        imageUrl: 'previewImageUrl',
+        domain: 'domain',
+      }),
+    ],
+  },
+}
+
+export { Bookmarks }

--- a/apps/frontend/src/collections/projects.ts
+++ b/apps/frontend/src/collections/projects.ts
@@ -1,19 +1,6 @@
-import { fetchOpenGraphMetadata } from '../lib/open-graph'
+import { withOpenGraphPreview } from '../lib/open-graph-hook'
 
 import type { CollectionConfig } from 'payload'
-
-/**
- * Lit une valeur de formulaire comme texte utile.
- *
- * Un champ vidé depuis l'administration arrive comme chaîne vide, pas comme
- * `null` : on le traite donc comme absent afin que la valeur automatique
- * reprenne la main.
- */
-const readTrimmedString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return trimmed === '' ? undefined : trimmed
-}
 
 /**
  * Projets du portfolio, décrits d'abord par leur URL.
@@ -94,28 +81,12 @@ const Projects: CollectionConfig = {
   ],
   hooks: {
     beforeChange: [
-      async ({ data, originalDoc, operation }) => {
-        const url = readTrimmedString(data.url)
-        if (!url) return data
-
-        // On n'interroge le site distant que si l'URL est nouvelle ou a changé,
-        // pour ne pas déclencher une requête à chaque sauvegarde.
-        const previousUrl = readTrimmedString(
-          (originalDoc as Record<string, unknown> | undefined)?.url
-        )
-        if (operation !== 'create' && url === previousUrl) return data
-
-        const metadata = await fetchOpenGraphMetadata(url)
-
-        return {
-          ...data,
-          url,
-          previewImageUrl: metadata.imageUrl,
-          // Les valeurs saisies à la main ne sont jamais écrasées.
-          title: readTrimmedString(data.title) ?? metadata.title ?? url,
-          description: readTrimmedString(data.description) ?? metadata.description ?? undefined,
-        }
-      },
+      withOpenGraphPreview({
+        url: 'url',
+        title: 'title',
+        description: 'description',
+        imageUrl: 'previewImageUrl',
+      }),
     ],
   },
 }

--- a/apps/frontend/src/collections/tags.ts
+++ b/apps/frontend/src/collections/tags.ts
@@ -1,0 +1,62 @@
+import type { CollectionConfig } from 'payload'
+
+/**
+ * Tags de classement des liens de veille.
+ *
+ * Ils sont une collection à part et non un champ texte libre : c'est ce qui permet
+ * de renommer un tag une seule fois et de le voir changer partout, et d'éviter les
+ * quasi-doublons (« React » / « react » / « ReactJS »).
+ */
+const Tags: CollectionConfig = {
+  slug: 'tags',
+  labels: { singular: 'Tag', plural: 'Tags' },
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'slug', 'updatedAt'],
+  },
+  access: {
+    // Le site public lit les tags pour proposer les filtres ; seul l'administrateur les modifie.
+    read: () => true,
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+    delete: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      label: 'Nom',
+      required: true,
+      unique: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      label: 'Identifiant',
+      unique: true,
+      index: true,
+      admin: {
+        readOnly: true,
+        description: 'Généré depuis le nom, utilisé dans les URL de filtre.',
+      },
+      hooks: {
+        beforeValidate: [
+          ({ data }) => {
+            const name = typeof data?.name === 'string' ? data.name : ''
+            return (
+              name
+                .normalize('NFD')
+                // Retire les diacritiques : « Accessibilité » devient « accessibilite ».
+                .replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-+|-+$/g, '')
+            )
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export { Tags }

--- a/apps/frontend/src/components/veille/bookmark-composer.tsx
+++ b/apps/frontend/src/components/veille/bookmark-composer.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { Link2, Loader2, Plus } from 'lucide-react'
+import { AnimatePresence, m } from 'motion/react'
+import { useRouter } from 'next/navigation'
+import { useState, type FormEvent } from 'react'
+
+import { EASE_OUT_QUINT } from '@/components/motion/primitives'
+import { canonicalizeUrl } from '@/lib/canonical-url'
+
+/**
+ * Formulaire d'ajout réservé à l'administrateur connecté.
+ *
+ * Il n'est rendu que lorsque la session Payload est valide, et l'API refuse de
+ * toute façon l'écriture sans session : le contrôle visuel est un confort, pas la
+ * barrière de sécurité.
+ *
+ * L'intérêt de l'avoir ici plutôt que dans `/admin` est le geste sur téléphone :
+ * coller un lien depuis la page publique, sans détour par l'administration.
+ */
+function BookmarkComposer() {
+  const router = useRouter()
+  const [draft, setDraft] = useState('')
+  const [status, setStatus] = useState<'idle' | 'saving'>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+
+  async function addBookmark(raw: string) {
+    const url = canonicalizeUrl(raw)
+    if (!url) {
+      setMessage('Ce lien ne ressemble pas à une URL valide.')
+      return
+    }
+
+    setStatus('saving')
+    setMessage(null)
+
+    try {
+      const response = await fetch('/api/bookmarks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // La session Payload voyage par cookie : rien à porter à la main.
+        credentials: 'include',
+        body: JSON.stringify({ url }),
+      })
+
+      if (response.status === 403 || response.status === 401) {
+        setMessage('Session expirée. Reconnecte-toi depuis /admin.')
+        return
+      }
+
+      if (!response.ok) {
+        // Le cas le plus fréquent est la violation d'unicité sur l'URL.
+        setMessage('Ce lien existe déjà ou n’a pas pu être enregistré.')
+        return
+      }
+
+      setDraft('')
+      // La liste est rendue côté serveur : on demande un nouveau rendu plutôt
+      // que de dupliquer l'état de la collection dans le navigateur.
+      router.refresh()
+    } catch {
+      setMessage('Enregistrement impossible. Vérifie ta connexion.')
+    } finally {
+      setStatus('idle')
+    }
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (status === 'saving') return
+    void addBookmark(draft)
+  }
+
+  const saving = status === 'saving'
+
+  return (
+    <>
+      <form className="search-bar veille-add-bar" onSubmit={submit}>
+        <Link2 size={17} />
+        <label className="sr-only" htmlFor="veille-url">
+          Ajouter un lien
+        </label>
+        <input
+          id="veille-url"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value)
+            setMessage(null)
+          }}
+          onPaste={(event) => {
+            const pasted = event.clipboardData.getData('text')
+            if (canonicalizeUrl(pasted)) {
+              event.preventDefault()
+              setDraft(pasted)
+              void addBookmark(pasted)
+            }
+          }}
+          placeholder="Collez votre lien ici…"
+          inputMode="url"
+          autoComplete="off"
+          aria-invalid={message !== null}
+          disabled={saving}
+        />
+        <button type="submit" disabled={saving}>
+          {saving ? (
+            <>
+              <Loader2 className="veille-spinner" size={14} /> Ajout…
+            </>
+          ) : (
+            <>
+              <Plus size={14} /> Ajouter
+            </>
+          )}
+        </button>
+      </form>
+      <AnimatePresence>
+        {message ? (
+          <m.p
+            className="veille-error"
+            role="alert"
+            initial={{ opacity: 0, y: -6, height: 0 }}
+            animate={{ opacity: 1, y: 0, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.3, ease: EASE_OUT_QUINT }}
+          >
+            {message}
+          </m.p>
+        ) : null}
+      </AnimatePresence>
+    </>
+  )
+}
+
+export { BookmarkComposer }

--- a/apps/frontend/src/components/veille/bookmark-grid.tsx
+++ b/apps/frontend/src/components/veille/bookmark-grid.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { AnimatePresence, m } from 'motion/react'
+import Image from 'next/image'
+import { useMemo, useState } from 'react'
+
+import { EASE_OUT_QUINT } from '@/components/motion/primitives'
+
+import type { BookmarkView } from '@/lib/bookmarks'
+
+const ALL_TAGS = 'Tous'
+const COVER_TONES = ['violet', 'coral', 'blue', 'green', 'cyan', 'mono'] as const
+
+/** Teinte stable par domaine : la même carte garde sa couleur d'un rendu à l'autre. */
+function coverTone(domain: string) {
+  let hash = 0
+  for (const char of domain) hash = (hash * 31 + char.codePointAt(0)!) % 997
+  return COVER_TONES[hash % COVER_TONES.length]
+}
+
+interface BookmarkGridProps {
+  bookmarks: BookmarkView[]
+}
+
+/**
+ * Grille filtrable des liens de veille.
+ *
+ * Les données arrivent déjà rendues par le serveur ; ce composant ne gère que le
+ * filtre par tag et les transitions. Il ne peut ni ajouter ni supprimer un lien :
+ * l'écriture passe par le formulaire réservé à l'administrateur.
+ */
+function BookmarkGrid({ bookmarks }: BookmarkGridProps) {
+  const [activeTag, setActiveTag] = useState(ALL_TAGS)
+
+  const tags = useMemo(() => {
+    const all = new Set<string>()
+    for (const bookmark of bookmarks) for (const tag of bookmark.tags) all.add(tag)
+    return [ALL_TAGS, ...[...all].sort((a, b) => a.localeCompare(b, 'fr'))]
+  }, [bookmarks])
+
+  const visibleBookmarks = useMemo(
+    () =>
+      activeTag === ALL_TAGS
+        ? bookmarks
+        : bookmarks.filter((bookmark) => bookmark.tags.includes(activeTag)),
+    [bookmarks, activeTag]
+  )
+
+  if (bookmarks.length === 0) {
+    return <p className="veille-empty">Aucun lien publié pour l’instant.</p>
+  }
+
+  return (
+    <>
+      <div className="filter-row veille-tags" role="group" aria-label="Filtrer par tag">
+        {tags.map((tag) => (
+          <button
+            className={tag === activeTag ? 'is-active' : undefined}
+            key={tag}
+            onClick={() => setActiveTag(tag)}
+            type="button"
+            aria-pressed={tag === activeTag}
+          >
+            {tag}
+          </button>
+        ))}
+      </div>
+      <div className="veille-grid">
+        <AnimatePresence mode="popLayout" initial={false}>
+          {visibleBookmarks.map((bookmark) => (
+            <m.article
+              className="veille-card"
+              key={bookmark.id}
+              layout
+              initial={{ opacity: 0, scale: 0.9, y: 14 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
+            >
+              <a href={bookmark.url} target="_blank" rel="noreferrer">
+                <BookmarkCover bookmark={bookmark} />
+                <p>{bookmark.domain}</p>
+                <h2>{bookmark.title}</h2>
+                {bookmark.tags.length > 0 ? (
+                  <span className="veille-tag-list">
+                    {bookmark.tags.map((tag) => (
+                      <span key={tag}>{tag}</span>
+                    ))}
+                  </span>
+                ) : null}
+              </a>
+            </m.article>
+          ))}
+        </AnimatePresence>
+      </div>
+      {visibleBookmarks.length === 0 ? (
+        <p className="veille-empty">Aucun lien avec ce tag pour l’instant.</p>
+      ) : null}
+    </>
+  )
+}
+
+/**
+ * Visuel de la carte : l'aperçu Open Graph quand il existe, sinon le favicon.
+ *
+ * L'image distante peut disparaître après coup ; en cas d'erreur de chargement on
+ * bascule sur le favicon plutôt que de laisser un cadre vide.
+ */
+function BookmarkCover({ bookmark }: { bookmark: BookmarkView }) {
+  const [previewFailed, setPreviewFailed] = useState(false)
+  const showPreview = Boolean(bookmark.previewImageUrl) && !previewFailed
+
+  if (showPreview) {
+    return (
+      <span className="veille-cover veille-cover-preview">
+        <Image
+          src={bookmark.previewImageUrl!}
+          alt=""
+          width={480}
+          height={252}
+          onError={() => setPreviewFailed(true)}
+          // Les domaines distants ne sont pas connus à l'avance : l'optimiseur
+          // Next exigerait une liste blanche que l'on ne peut pas maintenir.
+          unoptimized
+        />
+      </span>
+    )
+  }
+
+  return (
+    <span className={`veille-cover veille-cover-${coverTone(bookmark.domain)}`}>
+      <Image
+        // `sz` is a hint: Google returns the closest size it holds, so
+        // asking for 64 often yields 28px for a 40px slot. Requesting
+        // 128 covers the 2x display density on high-DPI screens.
+        src={`https://www.google.com/s2/favicons?domain=${bookmark.domain}&sz=128`}
+        alt=""
+        width={40}
+        height={40}
+        unoptimized
+      />
+    </span>
+  )
+}
+
+export { BookmarkGrid }

--- a/apps/frontend/src/lib/bookmarks.ts
+++ b/apps/frontend/src/lib/bookmarks.ts
@@ -1,0 +1,100 @@
+import { getPayload } from 'payload'
+
+import config from '@payload-config'
+
+import type { Bookmark } from '@/payload-types'
+
+/**
+ * Accès serveur aux liens de veille.
+ *
+ * On interroge Payload en local (`getPayload`) plutôt que par HTTP : la page est un
+ * composant serveur rendu dans le même processus, un aller-retour réseau vers sa
+ * propre API n'apporterait rien.
+ */
+
+/** Forme minimale dont la vue a besoin, découplée des types générés par Payload. */
+interface BookmarkView {
+  id: string
+  url: string
+  domain: string
+  title: string
+  description: string | null
+  previewImageUrl: string | null
+  tags: string[]
+}
+
+const asText = (value: string | null | undefined): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+/**
+ * Extrait les noms de tags d'une relation Payload.
+ *
+ * Selon la profondeur de la requête, la relation contient soit des identifiants,
+ * soit les documents complets. Ici la profondeur vaut 1, donc on attend des objets
+ * et on ignore les identifiants nus.
+ */
+const readTagNames = (relation: Bookmark['tags']): string[] => {
+  if (!relation) return []
+
+  const names: string[] = []
+  for (const entry of relation) {
+    if (typeof entry === 'number') continue
+    const name = asText(entry.name)
+    if (name) names.push(name)
+  }
+  return names
+}
+
+/** Domaine stocké, ou déduit de l'URL si le champ automatique est vide. */
+const readDomain = (doc: Bookmark): string => {
+  const stored = asText(doc.domain)
+  if (stored) return stored
+
+  try {
+    return new URL(doc.url).hostname
+  } catch {
+    return ''
+  }
+}
+
+const toView = (doc: Bookmark): BookmarkView => {
+  const domain = readDomain(doc)
+
+  return {
+    id: String(doc.id),
+    url: doc.url,
+    domain,
+    title: asText(doc.title) ?? domain,
+    description: asText(doc.description),
+    previewImageUrl: asText(doc.previewImageUrl),
+    tags: readTagNames(doc.tags),
+  }
+}
+
+/**
+ * Liste les liens visibles sur le site, du plus récent au plus ancien.
+ *
+ * Les liens décochés (`active: false`) sont exclus ici, et non filtrés dans la
+ * vue : ils ne doivent pas être envoyés au navigateur du tout.
+ */
+const listPublicBookmarks = async (): Promise<BookmarkView[]> => {
+  const payload = await getPayload({ config })
+
+  const result = await payload.find({
+    collection: 'bookmarks',
+    where: { active: { equals: true } },
+    sort: '-createdAt',
+    limit: 200,
+    depth: 1,
+    // On passe par le contrôle d'accès normal : la lecture est publique, donc
+    // aucune raison de le contourner depuis le rendu serveur.
+    overrideAccess: false,
+  })
+
+  return result.docs.map(toView)
+}
+
+export { listPublicBookmarks, type BookmarkView }

--- a/apps/frontend/src/lib/canonical-url.test.ts
+++ b/apps/frontend/src/lib/canonical-url.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { canonicalizeUrl, deriveNameFromDomain, extractDomain } from './canonical-url'
+
+/**
+ * La forme canonique est la clé d'unicité en base : ces tests fixent à la fois ce
+ * qui doit être considéré comme un doublon et, tout aussi important, ce qui doit
+ * rester distinct.
+ */
+describe('canonicalizeUrl', () => {
+  it('complète un schéma absent', () => {
+    expect(canonicalizeUrl('react.dev')).toBe('https://react.dev/')
+  })
+
+  it('retire le www de tête et met l’hôte en minuscules', () => {
+    expect(canonicalizeUrl('https://WWW.React.dev/')).toBe('https://react.dev/')
+  })
+
+  it('retire le fragment', () => {
+    expect(canonicalizeUrl('https://react.dev/learn#state')).toBe('https://react.dev/learn')
+  })
+
+  it('retire la barre oblique finale mais garde celle de la racine', () => {
+    expect(canonicalizeUrl('https://react.dev/learn/')).toBe('https://react.dev/learn')
+    expect(canonicalizeUrl('https://react.dev')).toBe('https://react.dev/')
+  })
+
+  it('supprime les identifiants intégrés à l’URL', () => {
+    expect(canonicalizeUrl('https://user:pass@react.dev/learn')).toBe('https://react.dev/learn')
+  })
+
+  it.each([
+    ['utm_source', 'https://react.dev/learn?utm_source=newsletter'],
+    ['utm_campaign', 'https://react.dev/learn?utm_campaign=launch&utm_medium=email'],
+    ['fbclid', 'https://react.dev/learn?fbclid=abc123'],
+    ['gclid', 'https://react.dev/learn?gclid=abc123'],
+    ['matomo pk_', 'https://react.dev/learn?pk_campaign=x'],
+  ])('retire les paramètres de suivi : %s', (_label, input) => {
+    expect(canonicalizeUrl(input)).toBe('https://react.dev/learn')
+  })
+
+  it('conserve les paramètres porteurs de sens', () => {
+    expect(canonicalizeUrl('https://youtube.com/watch?v=abc&utm_source=x')).toBe(
+      'https://youtube.com/watch?v=abc'
+    )
+  })
+
+  it('rend l’ordre des paramètres non significatif', () => {
+    expect(canonicalizeUrl('https://example.com/p?b=2&a=1')).toBe(
+      canonicalizeUrl('https://example.com/p?a=1&b=2')
+    )
+  })
+
+  it('garde deux chemins distincts distincts', () => {
+    expect(canonicalizeUrl('https://react.dev/learn')).not.toBe(
+      canonicalizeUrl('https://react.dev/reference')
+    )
+  })
+
+  it('garde un sous-domaine distinct du domaine racine', () => {
+    expect(canonicalizeUrl('https://developer.mozilla.org/')).not.toBe(
+      canonicalizeUrl('https://mozilla.org/')
+    )
+  })
+
+  it.each([
+    ['chaîne vide', ''],
+    ['espaces seuls', '   '],
+    ['hôte sans point', 'https://localhost:3000/'],
+    ['schéma non http', 'ftp://example.com/'],
+    ['schéma javascript', 'javascript:alert(1)'],
+    ['texte quelconque', 'pas une url du tout'],
+  ])('refuse une entrée inexploitable : %s', (_label, input) => {
+    expect(canonicalizeUrl(input)).toBeNull()
+  })
+})
+
+describe('extractDomain', () => {
+  it('retourne le domaine sans www', () => {
+    expect(extractDomain('https://www.anthropic.com/news')).toBe('anthropic.com')
+  })
+
+  it('conserve le sous-domaine', () => {
+    expect(extractDomain('https://developer.mozilla.org/docs')).toBe('developer.mozilla.org')
+  })
+
+  it('retourne null sur une URL invalide', () => {
+    expect(extractDomain('pas-une-url')).toBeNull()
+  })
+})
+
+describe('deriveNameFromDomain', () => {
+  it.each([
+    ['react.dev', 'React'],
+    ['developer.mozilla.org', 'Mozilla'],
+    ['tailwindcss.com', 'Tailwindcss'],
+  ])('déduit un nom lisible de %s', (domain, expected) => {
+    expect(deriveNameFromDomain(domain)).toBe(expected)
+  })
+})

--- a/apps/frontend/src/lib/canonical-url.ts
+++ b/apps/frontend/src/lib/canonical-url.ts
@@ -1,0 +1,107 @@
+/**
+ * Normalisation des URL avant stockage.
+ *
+ * Un même lien copié depuis une newsletter, un tweet ou la barre d'adresse arrive
+ * sous trois formes différentes. On les ramène à une écriture unique afin que la
+ * contrainte d'unicité en base détecte réellement les doublons — sans pour autant
+ * confondre deux pages distinctes du même site.
+ */
+
+/**
+ * Paramètres de suivi retirés systématiquement : ils identifient la campagne qui
+ * a amené le lien, jamais la ressource elle-même.
+ */
+const TRACKING_PARAMS: readonly string[] = [
+  'fbclid',
+  'gclid',
+  'igshid',
+  'mc_cid',
+  'mc_eid',
+  'msclkid',
+  'ref_src',
+  'ref_url',
+  's_cid',
+  'twclid',
+  'vero_conv',
+  'vero_id',
+  'yclid',
+]
+
+/** Préfixes de paramètres de suivi : `utm_source`, `utm_campaign`, etc. */
+const TRACKING_PREFIXES: readonly string[] = ['utm_', 'pk_', 'mtm_', 'hsa_', 'oly_', 'wt_']
+
+const isTrackingParam = (key: string): boolean => {
+  const lower = key.toLowerCase()
+  if (TRACKING_PARAMS.includes(lower)) return true
+  return TRACKING_PREFIXES.some((prefix) => lower.startsWith(prefix))
+}
+
+/**
+ * Réécrit une URL sous sa forme canonique.
+ *
+ * - complète le schéma manquant (`react.dev` → `https://react.dev`)
+ * - met l'hôte en minuscules et retire le `www.` de tête
+ * - supprime les paramètres de suivi, puis trie ceux qui restent
+ * - retire le fragment, qui ne désigne pas une autre ressource
+ * - retire la barre oblique finale, sauf à la racine
+ *
+ * Retourne `null` si la chaîne n'est pas une URL http(s) exploitable. Ne fait
+ * aucune requête réseau : la validation de la cible relève de `open-graph.ts`.
+ */
+const canonicalizeUrl = (raw: string): string | null => {
+  const candidate = raw.trim()
+  if (!candidate) return null
+
+  let url: URL
+  try {
+    // Une saisie sans schéma est traitée comme https, cas courant d'un copier-coller.
+    url = new URL(candidate.includes('://') ? candidate : `https://${candidate}`)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+
+  // Un hôte sans point n'est pas un domaine public (`localhost`, intranet…).
+  if (!url.hostname.includes('.')) return null
+
+  // Les identifiants n'ont rien à faire dans un lien stocké.
+  url.username = ''
+  url.password = ''
+
+  url.hostname = url.hostname.toLowerCase().replace(/^www\./, '')
+  url.hash = ''
+
+  const kept = [...url.searchParams.entries()].filter(([key]) => !isTrackingParam(key))
+  // Le tri rend l'ordre des paramètres non significatif : `?a=1&b=2` et
+  // `?b=2&a=1` désignent la même page et doivent produire la même clé.
+  kept.sort(([a], [b]) => a.localeCompare(b))
+  url.search = ''
+  for (const [key, value] of kept) url.searchParams.append(key, value)
+
+  // `/docs/` et `/docs` sont la même page ; `/` reste `/`.
+  if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+    url.pathname = url.pathname.slice(0, -1)
+  }
+
+  return url.href
+}
+
+/** Domaine affichable, sans `www.`. `null` si l'URL est inexploitable. */
+const extractDomain = (raw: string): string | null => {
+  const canonical = canonicalizeUrl(raw)
+  if (!canonical) return null
+  return new URL(canonical).hostname
+}
+
+/**
+ * Nom lisible déduit du domaine, utilisé quand la page distante n'expose pas de
+ * titre : `developer.mozilla.org` → `Mozilla`.
+ */
+const deriveNameFromDomain = (domain: string): string => {
+  const parts = domain.split('.')
+  const label = parts.length > 2 ? parts[parts.length - 2] : parts[0]
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+export { canonicalizeUrl, deriveNameFromDomain, extractDomain }

--- a/apps/frontend/src/lib/open-graph-hook.ts
+++ b/apps/frontend/src/lib/open-graph-hook.ts
@@ -1,0 +1,94 @@
+import { canonicalizeUrl, deriveNameFromDomain } from './canonical-url'
+import { fetchOpenGraphMetadata } from './open-graph'
+
+import type { CollectionBeforeChangeHook } from 'payload'
+
+/**
+ * Hook `beforeChange` partagé : renseigne un aperçu depuis les balises Open Graph
+ * de l'URL saisie.
+ *
+ * Deux collections en dépendent (`projects` et `bookmarks`) et le comportement
+ * attendu est identique : normaliser l'URL, aller chercher titre/description/image
+ * une seule fois, et ne jamais écraser ce qui a été saisi à la main. Le hook est
+ * donc paramétré par les noms de champs plutôt que dupliqué.
+ */
+
+/** Noms des champs alimentés par le hook dans la collection appelante. */
+interface OpenGraphPreviewFields {
+  /** Champ portant l'URL saisie. Il est réécrit sous sa forme canonique. */
+  url: string
+  /** Champ titre, complété si laissé vide. */
+  title: string
+  /** Champ description, complété si laissé vide. */
+  description?: string
+  /** Champ recevant l'URL de l'image d'aperçu. */
+  imageUrl: string
+  /** Champ recevant le domaine, utile pour l'affichage et le favicon. */
+  domain?: string
+}
+
+/**
+ * Lit une valeur de formulaire comme texte utile.
+ *
+ * Un champ vidé depuis l'administration arrive comme chaîne vide, pas comme
+ * `null` : on le traite donc comme absent afin que la valeur automatique
+ * reprenne la main.
+ */
+const readTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed === '' ? undefined : trimmed
+}
+
+/**
+ * Construit le hook `beforeChange` pour une collection décrite par ses champs.
+ *
+ * L'appel réseau n'a lieu que si l'URL est nouvelle ou a changé : une simple
+ * modification de tag ou de titre ne redéclenche pas de requête sortante.
+ */
+const withOpenGraphPreview = (fields: OpenGraphPreviewFields): CollectionBeforeChangeHook => {
+  return async ({ data, originalDoc, operation }) => {
+    const record = data as Record<string, unknown>
+    const raw = readTrimmedString(record[fields.url])
+    if (!raw) return data
+
+    const url = canonicalizeUrl(raw)
+    // URL inexploitable : on laisse la validation du champ produire l'erreur
+    // plutôt que d'écrire une valeur à moitié normalisée.
+    if (!url) return data
+
+    const domain = new URL(url).hostname
+    const previous = originalDoc as Record<string, unknown> | undefined
+    const previousUrl = readTrimmedString(previous?.[fields.url])
+
+    // Rien de nouveau côté URL : on garde l'aperçu déjà en base.
+    if (operation !== 'create' && url === previousUrl) {
+      return { ...data, [fields.url]: url }
+    }
+
+    const metadata = await fetchOpenGraphMetadata(url)
+
+    const next: Record<string, unknown> = {
+      ...record,
+      [fields.url]: url,
+      [fields.imageUrl]: metadata.imageUrl,
+      // Les valeurs saisies à la main ne sont jamais écrasées. En dernier
+      // recours, le nom déduit du domaine reste plus lisible que l'URL brute.
+      [fields.title]:
+        readTrimmedString(record[fields.title]) ?? metadata.title ?? deriveNameFromDomain(domain),
+    }
+
+    if (fields.description) {
+      next[fields.description] =
+        readTrimmedString(record[fields.description]) ?? metadata.description ?? undefined
+    }
+
+    if (fields.domain) {
+      next[fields.domain] = domain
+    }
+
+    return next
+  }
+}
+
+export { readTrimmedString, withOpenGraphPreview }

--- a/apps/frontend/src/migrations/20260817_104541_bookmarks.json
+++ b/apps/frontend/src/migrations/20260817_104541_bookmarks.json
@@ -1,0 +1,1551 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_id": {
+          "name": "cover_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_url_idx": {
+          "name": "projects_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_idx": {
+          "name": "projects_cover_idx",
+          "columns": [
+            {
+              "expression": "cover_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_cover_id_media_id_fk": {
+          "name": "projects_cover_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": ["cover_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_url_idx": {
+          "name": "bookmarks_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_domain_idx": {
+          "name": "bookmarks_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_active_idx": {
+          "name": "bookmarks_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_updated_at_idx": {
+          "name": "bookmarks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_created_at_idx": {
+          "name": "bookmarks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks_rels": {
+      "name": "bookmarks_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_rels_order_idx": {
+          "name": "bookmarks_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_parent_idx": {
+          "name": "bookmarks_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_path_idx": {
+          "name": "bookmarks_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_tags_id_idx": {
+          "name": "bookmarks_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_rels_parent_fk": {
+          "name": "bookmarks_rels_parent_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_rels_tags_fk": {
+          "name": "bookmarks_rels_tags_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projects_id": {
+          "name": "projects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarks_id": {
+          "name": "bookmarks_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_projects_id_idx": {
+          "name": "payload_locked_documents_rels_projects_id_idx",
+          "columns": [
+            {
+              "expression": "projects_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_bookmarks_id_idx": {
+          "name": "payload_locked_documents_rels_bookmarks_id_idx",
+          "columns": [
+            {
+              "expression": "bookmarks_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_projects_fk": {
+          "name": "payload_locked_documents_rels_projects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "projects",
+          "columnsFrom": ["projects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_bookmarks_fk": {
+          "name": "payload_locked_documents_rels_bookmarks_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmarks_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "625e2be5-aaa7-4bd4-9b8e-37da17702054",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/apps/frontend/src/migrations/20260817_104541_bookmarks.ts
+++ b/apps/frontend/src/migrations/20260817_104541_bookmarks.ts
@@ -1,0 +1,72 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TABLE "tags" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"name" varchar NOT NULL,
+  	"slug" varchar,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  CREATE TABLE "bookmarks" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"url" varchar NOT NULL,
+  	"title" varchar,
+  	"description" varchar,
+  	"domain" varchar,
+  	"preview_image_url" varchar,
+  	"active" boolean DEFAULT true,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  CREATE TABLE "bookmarks_rels" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"order" integer,
+  	"parent_id" integer NOT NULL,
+  	"path" varchar NOT NULL,
+  	"tags_id" integer
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "tags_id" integer;
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "bookmarks_id" integer;
+  ALTER TABLE "bookmarks_rels" ADD CONSTRAINT "bookmarks_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."bookmarks"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "bookmarks_rels" ADD CONSTRAINT "bookmarks_rels_tags_fk" FOREIGN KEY ("tags_id") REFERENCES "public"."tags"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE UNIQUE INDEX "tags_name_idx" ON "tags" USING btree ("name");
+  CREATE UNIQUE INDEX "tags_slug_idx" ON "tags" USING btree ("slug");
+  CREATE INDEX "tags_updated_at_idx" ON "tags" USING btree ("updated_at");
+  CREATE INDEX "tags_created_at_idx" ON "tags" USING btree ("created_at");
+  CREATE UNIQUE INDEX "bookmarks_url_idx" ON "bookmarks" USING btree ("url");
+  CREATE INDEX "bookmarks_domain_idx" ON "bookmarks" USING btree ("domain");
+  CREATE INDEX "bookmarks_active_idx" ON "bookmarks" USING btree ("active");
+  CREATE INDEX "bookmarks_updated_at_idx" ON "bookmarks" USING btree ("updated_at");
+  CREATE INDEX "bookmarks_created_at_idx" ON "bookmarks" USING btree ("created_at");
+  CREATE INDEX "bookmarks_rels_order_idx" ON "bookmarks_rels" USING btree ("order");
+  CREATE INDEX "bookmarks_rels_parent_idx" ON "bookmarks_rels" USING btree ("parent_id");
+  CREATE INDEX "bookmarks_rels_path_idx" ON "bookmarks_rels" USING btree ("path");
+  CREATE INDEX "bookmarks_rels_tags_id_idx" ON "bookmarks_rels" USING btree ("tags_id");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_tags_fk" FOREIGN KEY ("tags_id") REFERENCES "public"."tags"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_bookmarks_fk" FOREIGN KEY ("bookmarks_id") REFERENCES "public"."bookmarks"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_tags_id_idx" ON "payload_locked_documents_rels" USING btree ("tags_id");
+  CREATE INDEX "payload_locked_documents_rels_bookmarks_id_idx" ON "payload_locked_documents_rels" USING btree ("bookmarks_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "tags" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "bookmarks" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "bookmarks_rels" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "tags" CASCADE;
+  DROP TABLE "bookmarks" CASCADE;
+  DROP TABLE "bookmarks_rels" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_tags_fk";
+  
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_bookmarks_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_tags_id_idx";
+  DROP INDEX "payload_locked_documents_rels_bookmarks_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "tags_id";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "bookmarks_id";`)
+}

--- a/apps/frontend/src/migrations/index.ts
+++ b/apps/frontend/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import * as migration_20260817_094223_initial from './20260817_094223_initial'
 import * as migration_20260817_100546_projects from './20260817_100546_projects'
+import * as migration_20260817_104541_bookmarks from './20260817_104541_bookmarks'
 
 export const migrations = [
   {
@@ -11,5 +12,10 @@ export const migrations = [
     up: migration_20260817_100546_projects.up,
     down: migration_20260817_100546_projects.down,
     name: '20260817_100546_projects',
+  },
+  {
+    up: migration_20260817_104541_bookmarks.up,
+    down: migration_20260817_104541_bookmarks.down,
+    name: '20260817_104541_bookmarks',
   },
 ]

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -70,6 +70,8 @@ export interface Config {
     users: User
     media: Media
     projects: Project
+    tags: Tag
+    bookmarks: Bookmark
     'payload-kv': PayloadKv
     'payload-locked-documents': PayloadLockedDocument
     'payload-preferences': PayloadPreference
@@ -80,6 +82,8 @@ export interface Config {
     users: UsersSelect<false> | UsersSelect<true>
     media: MediaSelect<false> | MediaSelect<true>
     projects: ProjectsSelect<false> | ProjectsSelect<true>
+    tags: TagsSelect<false> | TagsSelect<true>
+    bookmarks: BookmarksSelect<false> | BookmarksSelect<true>
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>
     'payload-locked-documents':
       | PayloadLockedDocumentsSelect<false>
@@ -200,6 +204,59 @@ export interface Project {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
+export interface Tag {
+  id: number
+  name: string
+  /**
+   * Généré depuis le nom, utilisé dans les URL de filtre.
+   */
+  slug?: string | null
+  updatedAt: string
+  createdAt: string
+}
+/**
+ * Collez l'URL : le reste est récupéré automatiquement.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "bookmarks".
+ */
+export interface Bookmark {
+  id: number
+  /**
+   * Normalisée automatiquement : les paramètres de suivi sont retirés.
+   */
+  url: string
+  /**
+   * Laissez vide pour reprendre le titre de la page distante.
+   */
+  title?: string | null
+  /**
+   * Laissez vide pour reprendre la description de la page distante.
+   */
+  description?: string | null
+  /**
+   * Déduit de l'URL, utilisé pour l'affichage et le favicon.
+   */
+  domain?: string | null
+  /**
+   * Extraite des balises Open Graph à chaque modification de l'URL.
+   */
+  previewImageUrl?: string | null
+  /**
+   * Sert aux filtres de la page Veille.
+   */
+  tags?: (number | Tag)[] | null
+  /**
+   * Décochez pour retirer le lien du site sans le supprimer.
+   */
+  active?: boolean | null
+  updatedAt: string
+  createdAt: string
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -233,6 +290,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'projects'
         value: number | Project
+      } | null)
+    | ({
+        relationTo: 'tags'
+        value: number | Tag
+      } | null)
+    | ({
+        relationTo: 'bookmarks'
+        value: number | Bookmark
       } | null)
   globalSlug?: string | null
   user: {
@@ -328,6 +393,31 @@ export interface ProjectsSelect<T extends boolean = true> {
   previewImageUrl?: T
   cover?: T
   featured?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags_select".
+ */
+export interface TagsSelect<T extends boolean = true> {
+  name?: T
+  slug?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "bookmarks_select".
+ */
+export interface BookmarksSelect<T extends boolean = true> {
+  url?: T
+  title?: T
+  description?: T
+  domain?: T
+  previewImageUrl?: T
+  tags?: T
+  active?: T
   updatedAt?: T
   createdAt?: T
 }

--- a/apps/frontend/src/payload.config.ts
+++ b/apps/frontend/src/payload.config.ts
@@ -6,8 +6,10 @@ import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { buildConfig } from 'payload'
 import sharp from 'sharp'
 
+import { Bookmarks } from './collections/bookmarks'
 import { Media } from './collections/media'
 import { Projects } from './collections/projects'
+import { Tags } from './collections/tags'
 import { Users } from './collections/users'
 
 const filename = fileURLToPath(import.meta.url)
@@ -20,7 +22,7 @@ export default buildConfig({
       titleSuffix: '— Adem',
     },
   },
-  collections: [Users, Media, Projects],
+  collections: [Users, Media, Projects, Tags, Bookmarks],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET ?? '',
   typescript: {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ Le routeur est découpé en deux groupes, qui n'ajoutent aucun segment d'URL :
 | -------------- | ---------------------------------------------- |
 | `/`            | Hero conversationnelle et sélection de projets |
 | `/projets`     | Liste des projets                              |
-| `/veille`      | Articles et notes techniques                   |
+| `/veille`      | Liens de veille servis par Payload             |
 | `/a-propos`    | Parcours et principes                          |
 | `/contact`     | Formulaire local prêt à connecter              |
 | `/liens`       | Démonstration du gestionnaire de favoris       |
@@ -49,19 +49,35 @@ Le routeur est découpé en deux groupes, qui n'ajoutent aucun segment d'URL :
 - `users` — collection d'authentification, propriétaire de l'accès à `/admin`.
 - `media` — uploads, lecture publique, écriture réservée aux utilisateurs connectés.
 - `projects` — projets du portfolio, décrits par leur URL, lecture publique.
+- `bookmarks` — liens de veille, décrits par leur URL, lecture publique.
+- `tags` — étiquettes de classement des liens, lecture publique.
 
-Les collections restantes (liens, tags) arriveront dans des lots suivants.
+### Aperçu automatique par l'URL
 
-### Aperçu automatique des projets
+Un projet comme un lien de veille se saisit avec une seule information : son URL.
+Un hook `beforeChange` lit alors les balises Open Graph de la page distante pour
+remplir le titre, la description et l'image d'aperçu. Cela évite de téléverser un
+visuel pour chaque entrée ; `projects` garde en plus le champ `cover` comme repli
+quand le site cible n'expose pas d'image exploitable.
 
-Un projet se saisit avec une seule information : son URL. Un hook `beforeChange`
-lit alors les balises Open Graph de la page distante pour remplir le titre, la
-description et l'image d'aperçu. Cela évite de téléverser un visuel pour chaque
-projet, tout en gardant le champ `cover` comme repli quand le site cible n'expose
-pas d'image exploitable.
+Ce hook est écrit une seule fois, dans `src/lib/open-graph-hook.ts`, et
+paramétré par les noms de champs de la collection appelante : les deux
+collections partagent le comportement au lieu d'en dupliquer deux variantes.
 
 Le hook n'interroge le site distant que lorsque l'URL change, et les valeurs
 saisies à la main ne sont jamais écrasées.
+
+### Canonicalisation des URL
+
+Avant tout enregistrement, l'URL passe par `src/lib/canonical-url.ts` : schéma
+complété, hôte en minuscules, `www.` et fragment retirés, paramètres de suivi
+(`utm_*`, `fbclid`, `gclid`…) supprimés, paramètres restants triés, barre oblique
+finale enlevée.
+
+Sans cette étape, l'index unique sur `url` ne servirait à rien : la même page
+collée depuis deux sources différentes produirait deux fiches. Les paramètres
+porteurs de sens, eux, sont conservés — `?v=abc` distingue bien deux vidéos.
+`src/lib/canonical-url.test.ts` verrouille les deux côtés de cette frontière.
 
 Comme cette requête part du serveur vers une adresse fournie par un utilisateur,
 elle constitue un risque de SSRF. `src/lib/open-graph.ts` la contient :
@@ -95,8 +111,26 @@ un volume persistant, sinon les médias disparaissent à chaque redéploiement.
 ## Sécurité des accès
 
 Les permissions vivent dans les fonctions `access` des collections Payload, donc
-côté serveur : `users` exige une session pour toute opération, `media` autorise la
-lecture publique mais réserve l'écriture aux utilisateurs connectés.
+côté serveur : `users` exige une session pour toute opération, `media`, `projects`,
+`bookmarks` et `tags` autorisent la lecture publique mais réservent l'écriture aux
+utilisateurs connectés.
+
+### Ajout d'un lien depuis la page publique
+
+`/veille` affiche un champ d'ajout, mais uniquement au propriétaire : la page est
+un composant serveur qui appelle `payload.auth()` sur les en-têtes de la requête et
+ne rend le formulaire que si la session est valide. Le formulaire envoie ensuite un
+`POST /api/bookmarks` avec le cookie de session.
+
+Ce champ existe pour un usage précis : coller un lien depuis un téléphone sans
+passer par `/admin`. Il n'ouvre aucune porte pour autant — la barrière est le
+`access.create` de la collection, pas l'absence du formulaire. Un visiteur qui
+appelle l'API directement reçoit un `403`, et le masquage du formulaire n'est qu'un
+confort d'affichage.
+
+Les visiteurs n'ont donc aucun moyen d'écrire : la grille publique ne propose ni
+ajout ni suppression, et l'ancien stockage `localStorage` de la page a été retiré
+en même temps que le formulaire public.
 
 Le RLS (Row Level Security) de PostgreSQL est **volontairement désactivé**. Il
 protège le cas où le navigateur interroge Postgres directement via la clé publique

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -17,6 +17,8 @@
 - Deux assets hero dédiés : `hero-brain-light.png` et `hero-brain-dark.png`.
 - Payload CMS monté dans Next.js (issue #2) : admin sur `/admin`, API sur `/api/*`.
 - Le backend Express a été supprimé ; `apps/frontend` est la seule application.
+- Liens de veille servis par Payload (issue #6) : collections `bookmarks` et `tags`,
+  `/veille` rendu côté serveur, ajout réservé au propriétaire connecté.
 
 ## Confirmed direction
 
@@ -24,8 +26,13 @@
   Les deux passent par la même variable `DATABASE_URI`.
 - Coolify pilotera les déploiements, les domaines et les sauvegardes.
 - La spécification fonctionnelle de référence est `docs/FEATURE_SPEC_CMS_AI.md`.
-- Les collections métier (projets, liens, tags) viendront dans des lots suivants ;
-  l'issue #2 ne pose que le socle `users` + `media`.
+- Les collections métier arrivent par lots : `users` + `media` en #2, `projects`,
+  `bookmarks` et `tags` en #6.
+- Le visiteur ne publie jamais de lien. L'écriture est réservée au propriétaire
+  connecté, pour que personne ne puisse polluer la grille de veille.
+- L'ajout d'un lien doit rester possible depuis un téléphone, sur la page publique,
+  sans ouvrir `/admin` : c'est la raison d'être du champ d'ajout dans `/veille`.
+- Un lien se saisit par son URL seule, jamais en téléversant une image.
 
 ## Product boundaries
 
@@ -47,6 +54,17 @@
   « Transaction » (6543) casse les migrations Payload.
 - Next 16 a supprimé la clé `eslint` de `NextConfig` ; elle a été retirée de
   `next.config.ts`.
+- La CLI Payload (`migrate:create`) exige un TTY. Depuis un agent, l'envelopper :
+  `script -q /dev/null pnpm --filter @portfolio/frontend migrate:create`.
+- Le hook d'aperçu Open Graph est partagé entre `projects` et `bookmarks`
+  (`src/lib/open-graph-hook.ts`), paramétré par les noms de champs.
+- Toute URL est canonicalisée avant enregistrement (`src/lib/canonical-url.ts`),
+  sinon l'index unique sur `url` laisserait passer des doublons.
+- Prettier et ESLint doivent être lancés depuis le workspace
+  (`pnpm --filter @portfolio/frontend exec …`), pas depuis la racine.
+- Un écran `500` sur toutes les routes `/api/*` et `/admin` après plusieurs
+  modifications vient en général du cache `.next` périmé, pas du code :
+  arrêter le serveur, `rm -rf apps/frontend/.next`, redémarrer.
 
 ## Validation
 
@@ -54,4 +72,7 @@
 - `pnpm lint`
 - `pnpm build`
 - `pnpm --filter @portfolio/frontend migrate` (nécessite `DATABASE_URI`)
-- Vérification navigateur sur `/`, `/liens`, `/demo` et `/admin`.
+- `pnpm test`
+- Vérification navigateur sur `/`, `/liens`, `/demo`, `/veille` et `/admin`.
+- Contrôle d'accès vérifié à l'API, seule vraie barrière : `GET /api/bookmarks`
+  répond `200`, tandis que `POST`/`DELETE` sans session répondent `403`.


### PR DESCRIPTION
Closes #6

## Summary

The veille page kept its links in `localStorage` behind a **public** add form: any
visitor could write to the grid, and nothing survived a change of browser. Links
now live in Payload — read by everyone, written only by me.

A link is entered as a URL and nothing else. A `beforeChange` hook reads the Open
Graph tags of the target page to fill the title, description, domain and preview
image, so no visual is ever uploaded.

## What changed

**Two new collections.** `bookmarks` (url, title, description, domain,
previewImageUrl, tags, active) and `tags` (name, auto-generated slug). Both are
publicly readable; create, update and delete each require a session.

**The Open Graph hook is now shared.** It was written inline inside the projects
collection; it moved to `src/lib/open-graph-hook.ts` and is parameterised by field
names, so `projects` and `bookmarks` share one implementation instead of drifting
apart. The hook only calls the remote site when the URL actually changes, and never
overwrites a value entered by hand.

**URLs are canonicalised before storage** (`src/lib/canonical-url.ts`): scheme
completed, host lowercased, `www.` and fragment dropped, tracking parameters
(`utm_*`, `fbclid`, `gclid`…) removed, remaining parameters sorted, trailing slash
trimmed. Without this the unique index on `url` would be useless — the same page
pasted from a newsletter and from a tweet would create two records. Parameters that
carry meaning are preserved, so `?v=abc` still distinguishes two videos.

**`/veille` is now a server component.** It reads through Payload's local API
rather than an HTTP round-trip to its own API, and excludes `active: false` links in
the query rather than filtering them in the view, so unpublished links never reach
the browser at all.

**Writes are owner-only.** The barrier is the collection `access` functions, not the
UI. The add form is rendered only when `payload.auth()` confirms a session; it exists
for one reason — pasting a link from a phone without going through `/admin`. The
public grid can no longer add or remove anything, and the old `localStorage` code
went away in the same commit rather than leaving an open door behind.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test` — 52 passing (26 canonicalisation + 26 Open Graph / SSRF)
- [x] `pnpm build` — `/veille` correctly emitted as `ƒ` (server-rendered on demand)
- [x] `pnpm --filter @portfolio/frontend migrate` — migration applied
- [x] Browser check on `/veille`, desktop and 375 px

## Validation results

Pasting `https://www.motion.dev/?utm_source=newsletter&utm_campaign=test#hero`
produced a single record:

| Field | Value |
| --- | --- |
| `url` | `https://motion.dev/` |
| `title` | Motion (prev Framer Motion): JavaScript & React animation library |
| `domain` | `motion.dev` |
| `previewImageUrl` | `https://images.motion.dev/og/fresh/v1/site/home-3jhn8b0abpu66.png` |

One paste: `www.` stripped, both `utm_*` parameters and the fragment removed, and
the title, description, domain and preview image filled in automatically — with no
upload.

Access control verified at the API layer, which is the real barrier:

| Request | Result |
| --- | --- |
| `GET /api/bookmarks` | **200** |
| `POST /api/bookmarks` without session | **403** |
| `DELETE /api/bookmarks/1` without session | **403** |
| `POST /api/tags` without session | **403** |

## Notes for review

- The migration is purely additive: three new tables, plus `tags_id` / `bookmarks_id`
  on `payload_locked_documents_rels`. No existing column is touched. `push` stays
  disabled, so the migration remains the only description of the schema.
- The Open Graph fetch targets a user-supplied address, so it is an SSRF surface.
  The guards in `src/lib/open-graph.ts` were already in place and are unchanged here;
  `src/lib/open-graph.test.ts` covers them and is meant to fail loudly if they are
  weakened.
- `listTagNames` was removed as dead code. The grid derives its filters from the
  bookmarks it received, which is better behaviour — it never offers a tag that
  filters to zero results.
- The duplicate-URL path is enforced by the unique index `bookmarks_url_idx` but was
  not exercised end to end, since reaching it requires an authenticated session.
- The Payload CLI regenerated `migrations/index.ts` with semicolons, against the
  repo's Prettier style; it was reformatted so the diff stays purely additive.

## Follow-up

#28 tracks replacing the remaining demo content across the site, which is unrelated
to this change.
