### PR TITLE
fix(frontend): allow assigning tags to veille links

### DIFF
--- a/apps/frontend/src/app/(site)/(home)/_styles.css
+++ b/apps/frontend/src/app/(site)/(home)/_styles.css
@@ -111,9 +111,8 @@
 }
 .button-primary {
   color: white;
-  /* Every stop kept at >=4.5:1 against white; the old #9a60ed tail was 3.98:1. */
-  background: linear-gradient(104deg, #2f71e8, #6344e0 62%, #8a4fd8);
-  box-shadow: 0 12px 25px rgb(103 85 245 / 28%);
+  background: var(--accent-gradient);
+  box-shadow: 0 12px 25px var(--accent-glow);
 }
 .button-primary:hover {
   filter: brightness(1.08);
@@ -270,9 +269,9 @@
   border-radius: 12px;
   place-items: center;
   color: white;
-  background: linear-gradient(145deg, #376ee8, #7948e8);
+  background: var(--accent-gradient);
   cursor: pointer;
-  box-shadow: 0 8px 20px rgb(103 85 245 / 28%);
+  box-shadow: 0 8px 20px var(--accent-glow);
   transition-property: transform, filter;
   transition-duration: 180ms;
 }
@@ -549,6 +548,11 @@
   border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
   box-shadow: 0 18px 45px rgb(30 37 58 / 10%);
 }
+/*
+  Fallback thumbnail when a project has no preview image. The accent fill is the
+  ground, the blurred orbs only add depth on top of it: they are round and soft,
+  so on their own they leave the corners bare and the white title unreadable.
+*/
 .project-visual {
   position: relative;
   display: grid;
@@ -556,6 +560,7 @@
   height: 125px;
   margin-bottom: 12px;
   border-radius: 7px;
+  background: var(--accent-gradient);
   place-items: center;
   isolation: isolate;
 }

--- a/apps/frontend/src/app/(site)/veille/_components/bookmark-composer.tsx
+++ b/apps/frontend/src/app/(site)/veille/_components/bookmark-composer.tsx
@@ -10,6 +10,10 @@ import { canonicalizeUrl } from '@/lib/canonical-url'
 
 import { VEILLE_CONTENT } from '../_content'
 
+import { TagSelector } from './tag-selector'
+
+import type { TagView } from '@/lib/tags'
+
 /**
  * Add form reserved for the signed-in admin.
  *
@@ -20,12 +24,19 @@ import { VEILLE_CONTENT } from '../_content'
  * Having it here rather than in `/admin` is about the gesture on a phone: pasting
  * a link from the public page, without a detour through the admin.
  */
-function BookmarkComposer() {
+interface BookmarkComposerProps {
+  tags: TagView[]
+}
+
+function BookmarkComposer({ tags }: BookmarkComposerProps) {
   const router = useRouter()
   const [draft, setDraft] = useState('')
   const [status, setStatus] = useState<'idle' | 'saving'>('idle')
   const [message, setMessage] = useState<string | null>(null)
-  const { composer } = VEILLE_CONTENT
+  // Deliberately kept across submissions: filing veille usually means adding
+  // several links under the same tag, and re-checking it every time would grate.
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([])
+  const { composer, tagPicker } = VEILLE_CONTENT
 
   async function addBookmark(raw: string) {
     const url = canonicalizeUrl(raw)
@@ -43,7 +54,9 @@ function BookmarkComposer() {
         headers: { 'Content-Type': 'application/json' },
         // The Payload session travels by cookie: nothing to carry by hand.
         credentials: 'include',
-        body: JSON.stringify({ url }),
+        // Payload expects relation identifiers; an empty list is valid and
+        // creates an untagged link, exactly as before.
+        body: JSON.stringify({ url, tags: selectedTagIds.map(Number) }),
       })
 
       if (response.status === 403 || response.status === 401) {
@@ -66,6 +79,12 @@ function BookmarkComposer() {
     } finally {
       setStatus('idle')
     }
+  }
+
+  function toggleTag(id: string) {
+    setSelectedTagIds((current) =>
+      current.includes(id) ? current.filter((entry) => entry !== id) : [...current, id]
+    )
   }
 
   function submit(event: FormEvent<HTMLFormElement>) {
@@ -116,6 +135,17 @@ function BookmarkComposer() {
           )}
         </button>
       </form>
+      {/*
+        Below the bar rather than inside it: selecting a tag stays optional and
+        must never stand between pasting a URL and it being saved.
+      */}
+      <TagSelector
+        tags={tags}
+        selectedIds={selectedTagIds}
+        onToggle={toggleTag}
+        disabled={saving}
+        ariaLabel={tagPicker.composerLabel}
+      />
       <AnimatePresence>
         {message ? (
           <m.p

--- a/apps/frontend/src/app/(site)/veille/_components/bookmark-grid.tsx
+++ b/apps/frontend/src/app/(site)/veille/_components/bookmark-grid.tsx
@@ -2,13 +2,17 @@
 
 import { AnimatePresence, m } from 'motion/react'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 
 import { EASE_OUT_QUINT } from '@/components/motion/primitives'
 
 import { VEILLE_CONTENT } from '../_content'
 
+import { CardTagEditor } from './card-tag-editor'
+
 import type { BookmarkView } from '@/lib/bookmarks'
+import type { TagView } from '@/lib/tags'
 
 const ALL_TAGS = VEILLE_CONTENT.filter.allTag
 const COVER_TONES = ['violet', 'coral', 'blue', 'green', 'cyan', 'mono'] as const
@@ -22,6 +26,10 @@ function coverTone(domain: string) {
 
 interface BookmarkGridProps {
   bookmarks: BookmarkView[]
+  /** Whole vocabulary, offered by the per-card editor. Empty for a visitor. */
+  allTags: TagView[]
+  /** Only the owner may retag a link; a visitor gets a read-only grid. */
+  canEdit: boolean
 }
 
 /**
@@ -31,9 +39,13 @@ interface BookmarkGridProps {
  * the tag filter and the transitions. It can neither add nor delete a link:
  * writing goes through the form reserved for the admin.
  */
-function BookmarkGrid({ bookmarks }: BookmarkGridProps) {
+function BookmarkGrid({ bookmarks, allTags, canEdit }: BookmarkGridProps) {
+  const router = useRouter()
   const [activeTag, setActiveTag] = useState<string>(ALL_TAGS)
 
+  // Only the tags actually carried by a link: a filter returning nothing has no
+  // value. The editors list the whole vocabulary instead, so a fresh tag is still
+  // reachable.
   const tags = useMemo(() => {
     const all = new Set<string>()
     for (const bookmark of bookmarks) for (const tag of bookmark.tags) all.add(tag)
@@ -83,6 +95,14 @@ function BookmarkGrid({ bookmarks }: BookmarkGridProps) {
               exit={{ opacity: 0, scale: 0.9 }}
               transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
             >
+              {canEdit ? (
+                <CardTagEditor
+                  bookmarkId={bookmark.id}
+                  tags={allTags}
+                  selectedIds={bookmark.tagIds}
+                  onSaved={() => router.refresh()}
+                />
+              ) : null}
               <a href={bookmark.url} target="_blank" rel="noreferrer">
                 <BookmarkCover bookmark={bookmark} />
                 <p>{bookmark.domain}</p>

--- a/apps/frontend/src/app/(site)/veille/_components/card-tag-editor.tsx
+++ b/apps/frontend/src/app/(site)/veille/_components/card-tag-editor.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { Tags as TagsIcon } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+import { VEILLE_CONTENT } from '../_content'
+
+import { TagSelector } from './tag-selector'
+
+import type { TagView } from '@/lib/tags'
+
+/**
+ * Per-card tag editor, reserved for the signed-in owner.
+ *
+ * It sits outside the card's `<a>`: a button nested in a link is invalid markup
+ * and every click would navigate away instead of opening the popover.
+ *
+ * Saving happens on each toggle rather than behind a confirm button — the
+ * gesture is meant to be "click the tag, pick the right one, done".
+ */
+interface CardTagEditorProps {
+  bookmarkId: string
+  tags: TagView[]
+  selectedIds: string[]
+  onSaved: () => void
+}
+
+function CardTagEditor({ bookmarkId, tags, selectedIds, onSaved }: CardTagEditorProps) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [failed, setFailed] = useState(false)
+  // Optimistic copy: the popover reflects the click immediately, while the server
+  // list only catches up after `router.refresh()`.
+  const [draftIds, setDraftIds] = useState(selectedIds)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { tagPicker } = VEILLE_CONTENT
+
+  // The server list is authoritative once a refresh lands.
+  useEffect(() => {
+    setDraftIds(selectedIds)
+  }, [selectedIds])
+
+  // Escape and outside clicks close the popover — the usual way out of a layer
+  // opened by mistake.
+  useEffect(() => {
+    if (!open) return
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [open])
+
+  async function toggleTag(id: string) {
+    const next = draftIds.includes(id)
+      ? draftIds.filter((entry) => entry !== id)
+      : [...draftIds, id]
+
+    const previous = draftIds
+    setDraftIds(next)
+    setSaving(true)
+    setFailed(false)
+
+    try {
+      const response = await fetch(`/api/bookmarks/${bookmarkId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tags: next.map(Number) }),
+      })
+
+      if (!response.ok) {
+        // Roll back: leaving the optimistic state would claim a save that never happened.
+        setDraftIds(previous)
+        setFailed(true)
+        return
+      }
+
+      onSaved()
+    } catch {
+      setDraftIds(previous)
+      setFailed(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="veille-tag-editor" ref={containerRef}>
+      <button
+        className="veille-tag-editor-trigger"
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        aria-label={tagPicker.openLabel}
+        title={tagPicker.openLabel}
+      >
+        <TagsIcon size={13} aria-hidden />
+      </button>
+      {open ? (
+        <div className="veille-tag-editor-popover">
+          <TagSelector
+            tags={tags}
+            selectedIds={draftIds}
+            onToggle={toggleTag}
+            disabled={saving}
+            ariaLabel={tagPicker.cardLabel}
+          />
+          {failed ? (
+            <p className="veille-tag-editor-error" role="alert">
+              {tagPicker.saveFailed}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export { CardTagEditor }

--- a/apps/frontend/src/app/(site)/veille/_components/tag-selector.tsx
+++ b/apps/frontend/src/app/(site)/veille/_components/tag-selector.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Check } from 'lucide-react'
+
+import { VEILLE_CONTENT } from '../_content'
+
+import type { TagView } from '@/lib/tags'
+
+/**
+ * Checkable list of the existing tags.
+ *
+ * Shared by the composer and the per-card editor so both offer the same gesture.
+ * It lists the whole vocabulary, not only the tags already in use: a tag created
+ * in `/admin` has to be selectable, or it could never be attached to anything.
+ *
+ * Purely controlled — it holds no state and cannot create a tag. Creation stays
+ * in `/admin`, which is what keeps near-duplicates from piling up.
+ */
+interface TagSelectorProps {
+  tags: TagView[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  disabled?: boolean
+  /** Labels the group for screen readers; the two callers give it different wording. */
+  ariaLabel: string
+}
+
+function TagSelector({ tags, selectedIds, onToggle, disabled, ariaLabel }: TagSelectorProps) {
+  if (tags.length === 0) {
+    return <p className="veille-tag-picker-empty">{VEILLE_CONTENT.tagPicker.noTags}</p>
+  }
+
+  return (
+    <div className="veille-tag-picker" role="group" aria-label={ariaLabel}>
+      {tags.map((tag) => {
+        const selected = selectedIds.includes(tag.id)
+
+        return (
+          <button
+            className={selected ? 'is-selected' : undefined}
+            key={tag.id}
+            type="button"
+            onClick={() => onToggle(tag.id)}
+            disabled={disabled}
+            // The button carries the state itself: no separate checkbox to label.
+            aria-pressed={selected}
+          >
+            {selected ? <Check size={12} aria-hidden /> : null}
+            {tag.name}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export { TagSelector }

--- a/apps/frontend/src/app/(site)/veille/_content.ts
+++ b/apps/frontend/src/app/(site)/veille/_content.ts
@@ -28,6 +28,13 @@ export const VEILLE_CONTENT = {
     saveFailed: 'Ce lien existe déjà ou n’a pas pu être enregistré.',
     networkError: 'Enregistrement impossible. Vérifie ta connexion.',
   },
+  tagPicker: {
+    composerLabel: 'Tags à associer au lien',
+    cardLabel: 'Modifier les tags de ce lien',
+    noTags: 'Aucun tag pour l’instant. Créez-en dans /admin.',
+    openLabel: 'Modifier les tags',
+    saveFailed: 'Les tags n’ont pas pu être enregistrés.',
+  },
   grid: {
     emptyState: 'Aucun lien publié pour l’instant.',
     emptyFilteredState: 'Aucun lien avec ce tag pour l’instant.',

--- a/apps/frontend/src/app/(site)/veille/_styles.css
+++ b/apps/frontend/src/app/(site)/veille/_styles.css
@@ -209,31 +209,20 @@
   place-items: center;
   width: 26px;
   height: 26px;
-  border: 1px solid var(--accent-solid);
-  border-radius: 8px;
+  /*
+    Same primary fill as the site's other accent buttons. Fully opaque on
+    purpose: any opacity here blends the fill into the card behind it, and the
+    button then reads as a lighter, washed-out violet next to them.
+  */
+  border: 0;
+  border-radius: 7px;
   background: var(--accent-solid);
   color: white;
-  /*
-    Always visible, never hover-only: a control revealed on hover is invisible
-    to a first-time look and unreachable on touch. It stays slightly dimmed so
-    it does not compete with the card, and reaches full strength on interaction.
-  */
-  opacity: 0.75;
   cursor: pointer;
-  transition:
-    opacity 180ms ease,
-    background-color 180ms ease,
-    border-color 180ms ease;
-}
-.veille-card:hover .veille-tag-editor-trigger,
-.veille-tag-editor-trigger:hover,
-.veille-tag-editor-trigger:focus-visible,
-.veille-tag-editor-trigger[aria-expanded='true'] {
-  opacity: 1;
+  transition: background-color 180ms ease;
 }
 .veille-tag-editor-trigger:hover,
 .veille-tag-editor-trigger[aria-expanded='true'] {
-  border-color: var(--accent-2);
   background: var(--accent-2);
 }
 .veille-tag-editor-popover {

--- a/apps/frontend/src/app/(site)/veille/_styles.css
+++ b/apps/frontend/src/app/(site)/veille/_styles.css
@@ -208,7 +208,12 @@
   border-radius: 8px;
   background: var(--bg);
   color: var(--muted);
-  opacity: 0;
+  /*
+    Always visible, never hover-only: a control revealed on hover is invisible
+    to a first-time look and unreachable on touch. It stays dimmed so it does
+    not compete with the card, and comes to full strength on interaction.
+  */
+  opacity: 0.55;
   cursor: pointer;
   transition:
     opacity 180ms ease,
@@ -216,6 +221,7 @@
     border-color 180ms ease;
 }
 .veille-card:hover .veille-tag-editor-trigger,
+.veille-tag-editor-trigger:hover,
 .veille-tag-editor-trigger:focus-visible,
 .veille-tag-editor-trigger[aria-expanded='true'] {
   opacity: 1;

--- a/apps/frontend/src/app/(site)/veille/_styles.css
+++ b/apps/frontend/src/app/(site)/veille/_styles.css
@@ -142,25 +142,105 @@
   color: var(--muted);
   font-size: 12px;
 }
-.veille-remove {
+/* Checkable tag list, shared by the composer and the per-card editor. */
+.veille-tag-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.veille-tag-picker button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 11px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease;
+}
+.veille-tag-picker button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.veille-tag-picker button.is-selected {
+  border-color: var(--accent-solid);
+  background: var(--accent-solid);
+  color: white;
+}
+.veille-tag-picker button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.veille-tag-picker-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* Composer: the picker sits under the paste bar, never inside it. */
+.veille-add-bar + .veille-tag-picker,
+.veille-add-bar + .veille-tag-picker-empty {
+  margin-bottom: 22px;
+}
+
+/*
+  Per-card editor. Anchored outside the card's <a>: a button nested in a link is
+  invalid markup and every click would navigate instead of opening the popover.
+*/
+.veille-tag-editor {
   position: absolute;
   top: 8px;
   right: 8px;
+  z-index: 2;
+}
+.veille-tag-editor-trigger {
   display: grid;
   place-items: center;
-  width: 24px;
-  height: 24px;
+  width: 26px;
+  height: 26px;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--bg);
   color: var(--muted);
   opacity: 0;
   cursor: pointer;
-  transition: opacity 180ms ease;
+  transition:
+    opacity 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
-.veille-card:hover .veille-remove,
-.veille-remove:focus-visible {
+.veille-card:hover .veille-tag-editor-trigger,
+.veille-tag-editor-trigger:focus-visible,
+.veille-tag-editor-trigger[aria-expanded='true'] {
   opacity: 1;
+}
+.veille-tag-editor-trigger:hover,
+.veille-tag-editor-trigger[aria-expanded='true'] {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.veille-tag-editor-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: max-content;
+  max-width: 240px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: 0 16px 38px rgb(18 24 40 / 16%);
+}
+.veille-tag-editor-error {
+  margin: 8px 0 0;
+  color: #e5484d;
+  font-size: 12px;
 }
 .veille-empty {
   padding: 40px 0;

--- a/apps/frontend/src/app/(site)/veille/_styles.css
+++ b/apps/frontend/src/app/(site)/veille/_styles.css
@@ -135,11 +135,16 @@
   flex-wrap: wrap;
   gap: 6px;
 }
+/*
+  Accent background, in its soft pairing rather than --accent-solid: several
+  chips sit together on a card, and the solid fill would pull the eye away from
+  the link itself. --accent-on-soft is the variant kept readable on it (>=4.5:1).
+*/
 .veille-tag-list span {
   padding: 3px 9px;
   border-radius: 999px;
-  background: var(--surface-2, var(--bg));
-  color: var(--muted);
+  background: var(--accent-soft);
+  color: var(--accent-on-soft);
   font-size: 12px;
 }
 /* Checkable tag list, shared by the composer and the per-card editor. */
@@ -204,20 +209,20 @@
   place-items: center;
   width: 26px;
   height: 26px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--accent-solid);
   border-radius: 8px;
-  background: var(--bg);
-  color: var(--muted);
+  background: var(--accent-solid);
+  color: white;
   /*
     Always visible, never hover-only: a control revealed on hover is invisible
-    to a first-time look and unreachable on touch. It stays dimmed so it does
-    not compete with the card, and comes to full strength on interaction.
+    to a first-time look and unreachable on touch. It stays slightly dimmed so
+    it does not compete with the card, and reaches full strength on interaction.
   */
-  opacity: 0.55;
+  opacity: 0.75;
   cursor: pointer;
   transition:
     opacity 180ms ease,
-    color 180ms ease,
+    background-color 180ms ease,
     border-color 180ms ease;
 }
 .veille-card:hover .veille-tag-editor-trigger,
@@ -228,8 +233,8 @@
 }
 .veille-tag-editor-trigger:hover,
 .veille-tag-editor-trigger[aria-expanded='true'] {
-  border-color: var(--accent);
-  color: var(--text);
+  border-color: var(--accent-2);
+  background: var(--accent-2);
 }
 .veille-tag-editor-popover {
   position: absolute;

--- a/apps/frontend/src/app/(site)/veille/_styles.css
+++ b/apps/frontend/src/app/(site)/veille/_styles.css
@@ -210,20 +210,22 @@
   width: 26px;
   height: 26px;
   /*
-    Same primary fill as the site's other accent buttons. Fully opaque on
-    purpose: any opacity here blends the fill into the card behind it, and the
-    button then reads as a lighter, washed-out violet next to them.
+    Same accent fill as the primary buttons. `.button-primary` itself is sized
+    for a 46px call to action and cannot shrink to this 26px square, so the
+    token is applied directly. Fully opaque on purpose -- any opacity blends the
+    fill into the card behind it, and the button then reads as washed out.
   */
   border: 0;
   border-radius: 7px;
-  background: var(--accent-solid);
+  background: var(--accent-gradient);
   color: white;
   cursor: pointer;
-  transition: background-color 180ms ease;
+  box-shadow: 0 6px 14px var(--accent-glow);
+  transition: filter 180ms ease;
 }
 .veille-tag-editor-trigger:hover,
 .veille-tag-editor-trigger[aria-expanded='true'] {
-  background: var(--accent-2);
+  filter: brightness(1.08);
 }
 .veille-tag-editor-popover {
   position: absolute;

--- a/apps/frontend/src/app/(site)/veille/page.tsx
+++ b/apps/frontend/src/app/(site)/veille/page.tsx
@@ -2,6 +2,7 @@ import { headers } from 'next/headers'
 import { getPayload } from 'payload'
 
 import { listPublicBookmarks } from '@/lib/bookmarks'
+import { listAllTags } from '@/lib/tags'
 import config from '@payload-config'
 
 import { BookmarkComposer } from './_components/bookmark-composer'
@@ -26,9 +27,13 @@ async function isOwner(): Promise<boolean> {
 }
 
 async function WatchPage() {
-  // Reading is public and the session only decides whether to show the form:
-  // the two queries are independent.
-  const [bookmarks, owner] = await Promise.all([listPublicBookmarks(), isOwner()])
+  // Reading is public and the session only decides whether the editing controls
+  // are rendered: the queries are independent.
+  const [bookmarks, owner, allTags] = await Promise.all([
+    listPublicBookmarks(),
+    isOwner(),
+    listAllTags(),
+  ])
   const { heading } = VEILLE_CONTENT
 
   return (
@@ -38,8 +43,8 @@ async function WatchPage() {
         <h1>{heading.title}</h1>
         <p>{heading.lead}</p>
       </header>
-      {owner ? <BookmarkComposer /> : null}
-      <BookmarkGrid bookmarks={bookmarks} />
+      {owner ? <BookmarkComposer tags={allTags} /> : null}
+      <BookmarkGrid bookmarks={bookmarks} allTags={allTags} canEdit={owner} />
     </div>
   )
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -64,6 +64,19 @@
   --accent-soft: #eeeaff;
   /* Accent variant readable as text on --accent-soft (>=4.5:1). */
   --accent-on-soft: #5a49e0;
+  /*
+    Fill of every primary button on the site. Each stop stays >=4.5:1 against
+    white, so button labels pass WCAG AA anywhere along the ramp.
+  */
+  --accent-gradient: linear-gradient(104deg, #2f71e8, #6344e0 62%, #8a4fd8);
+  --accent-glow: rgb(103 85 245 / 28%);
+  /*
+    Blurred orbs behind a project thumbnail, used as the fallback when the
+    project has no preview image. Saturated on purpose in both themes: the
+    card title sits on top of them in white and needs a dark enough ground.
+  */
+  --orb-a: #4f46e5;
+  --orb-b: #7c3aed;
   --success: #19a76f;
   --success-text: #0a7049;
   --shadow: 0 24px 70px rgb(69 74 105 / 9%);
@@ -86,6 +99,11 @@
   --accent-soft: #1d1839;
   /* Accent variant readable as text on --accent-soft (>=4.5:1). */
   --accent-on-soft: #a59dff;
+  /* Same ramp in both themes: it is always read as white-on-accent. */
+  --accent-gradient: linear-gradient(104deg, #2f71e8, #6344e0 62%, #8a4fd8);
+  --accent-glow: rgb(103 85 245 / 28%);
+  --orb-a: #4338ca;
+  --orb-b: #6d28d9;
   --success: #3ecf8e;
   --success-text: #55dfa0;
   --shadow: 0 30px 90px rgb(0 0 0 / 36%);

--- a/apps/frontend/src/lib/bookmarks.ts
+++ b/apps/frontend/src/lib/bookmarks.ts
@@ -27,6 +27,8 @@ interface BookmarkView {
   description: string | null
   previewImageUrl: string | null
   tags: string[]
+  /** Relation identifiers, needed by the owner-only tag editor to know what is checked. */
+  tagIds: string[]
 }
 
 const asText = (value: string | null | undefined): string | null => {
@@ -36,22 +38,25 @@ const asText = (value: string | null | undefined): string | null => {
 }
 
 /**
- * Extracts tag names from a Payload relation.
+ * Extracts tag names and identifiers from a Payload relation.
  *
  * Depending on the query depth, the relation holds either identifiers or the full
  * documents. Depth is 1 here, so objects are expected and bare identifiers are
  * ignored.
  */
-const readTagNames = (relation: Bookmark['tags']): string[] => {
-  if (!relation) return []
+const readTags = (relation: Bookmark['tags']): { names: string[]; ids: string[] } => {
+  if (!relation) return { names: [], ids: [] }
 
   const names: string[] = []
+  const ids: string[] = []
   for (const entry of relation) {
     if (typeof entry === 'number') continue
     const name = asText(entry.name)
-    if (name) names.push(name)
+    if (!name) continue
+    names.push(name)
+    ids.push(String(entry.id))
   }
-  return names
+  return { names, ids }
 }
 
 /** Stored domain, or derived from the URL when the automatic field is empty. */
@@ -68,6 +73,7 @@ const readDomain = (doc: Bookmark): string => {
 
 const toView = (doc: Bookmark): BookmarkView => {
   const domain = readDomain(doc)
+  const { names, ids } = readTags(doc.tags)
 
   return {
     id: String(doc.id),
@@ -76,7 +82,8 @@ const toView = (doc: Bookmark): BookmarkView => {
     title: asText(doc.title) ?? domain,
     description: asText(doc.description),
     previewImageUrl: asText(doc.previewImageUrl),
-    tags: readTagNames(doc.tags),
+    tags: names,
+    tagIds: ids,
   }
 }
 
@@ -103,6 +110,10 @@ const readPublicBookmarks = async (): Promise<BookmarkView[]> => {
   return result.docs.map(toView)
 }
 
-const listPublicBookmarks = cachedRead(CONTENT_TAGS.bookmarks, readPublicBookmarks)
+const listPublicBookmarks = cachedRead(
+  CONTENT_TAGS.bookmarks,
+  'bookmarks:list',
+  readPublicBookmarks
+)
 
 export { listPublicBookmarks, type BookmarkView }

--- a/apps/frontend/src/lib/content-cache.ts
+++ b/apps/frontend/src/lib/content-cache.ts
@@ -55,15 +55,20 @@ const PAGES_BY_TAG: Record<ContentTag, { path: string; type?: 'layout' | 'page' 
  * Caches a read under its tag.
  *
  * `revalidate: false` because invalidation comes from the hooks, not from a
- * clock: a periodic refresh would only hit the database for nothing. The tag
- * doubles as the cache key, each read having its own and taking no argument.
+ * clock: a periodic refresh would only hit the database for nothing.
+ *
+ * `key` identifies the cache entry and must be unique across all reads, while
+ * `tag` decides what invalidates it. They are separate because several reads can
+ * legitimately share one tag — bookmarks and the tag vocabulary are always shown
+ * together and are purged together, but each needs its own entry. Passing the tag
+ * as the key too would make the second read overwrite the first.
  *
  * The tag still earns its keep even though invalidation goes through paths: it
  * isolates cache entries from each other and spares `/veille`, rendered
  * dynamically, from replaying the query on every visit.
  */
-const cachedRead = <T>(tag: ContentTag, read: () => Promise<T>): (() => Promise<T>) =>
-  unstable_cache(read, [tag], { tags: [tag], revalidate: false })
+const cachedRead = <T>(tag: ContentTag, key: string, read: () => Promise<T>): (() => Promise<T>) =>
+  unstable_cache(read, [key], { tags: [tag], revalidate: false })
 
 /**
  * Regenerates the pages that display this content.

--- a/apps/frontend/src/lib/site-content.ts
+++ b/apps/frontend/src/lib/site-content.ts
@@ -226,10 +226,10 @@ const readProjects = async (): Promise<ProjectView[]> => {
   return result.docs.map(toProjectView)
 }
 
-const getIdentity = cachedRead(CONTENT_TAGS.identity, readIdentity)
-const getProfile = cachedRead(CONTENT_TAGS.profile, readProfile)
-const listExperiences = cachedRead(CONTENT_TAGS.experiences, readExperiences)
-const listProjects = cachedRead(CONTENT_TAGS.projects, readProjects)
+const getIdentity = cachedRead(CONTENT_TAGS.identity, 'identity', readIdentity)
+const getProfile = cachedRead(CONTENT_TAGS.profile, 'profile', readProfile)
+const listExperiences = cachedRead(CONTENT_TAGS.experiences, 'experiences', readExperiences)
+const listProjects = cachedRead(CONTENT_TAGS.projects, 'projects', readProjects)
 
 export {
   getIdentity,

--- a/apps/frontend/src/lib/tags.ts
+++ b/apps/frontend/src/lib/tags.ts
@@ -1,0 +1,53 @@
+import { getPayload } from 'payload'
+
+import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
+import config from '@payload-config'
+
+/**
+ * Server-side access to the tag vocabulary.
+ *
+ * Tags are created in `/admin` only, so this module just reads them: the site
+ * offers them for selection but never adds to the list. That is what keeps
+ * near-duplicates ("React" / "react" / "ReactJS") from piling up.
+ *
+ * Cached under the bookmarks tag rather than one of its own: the two are always
+ * displayed together on `/veille`, and the `tags` collection already purges that
+ * tag on write, so a tag created in the admin reaches the selector immediately.
+ */
+
+/** Minimal shape the selector needs, decoupled from the Payload-generated types. */
+interface TagView {
+  id: string
+  name: string
+}
+
+const readAllTags = async (): Promise<TagView[]> => {
+  const payload = await getPayload({ config })
+
+  const result = await payload.find({
+    collection: 'tags',
+    sort: 'name',
+    limit: 200,
+    // Only the name is displayed: the relations are not needed here.
+    depth: 0,
+    overrideAccess: false,
+  })
+
+  return result.docs
+    .map((doc) => ({
+      id: String(doc.id),
+      name: typeof doc.name === 'string' ? doc.name.trim() : '',
+    }))
+    .filter((tag) => tag.name !== '')
+}
+
+/**
+ * Lists every existing tag, alphabetically.
+ *
+ * Unlike the filter row — which only shows tags actually carried by a link — this
+ * returns the whole vocabulary: a freshly created tag has to be selectable, or it
+ * could never be attached to anything.
+ */
+const listAllTags = cachedRead(CONTENT_TAGS.bookmarks, 'tags:list', readAllTags)
+
+export { listAllTags, type TagView }

--- a/apps/frontend/src/styles/layout.css
+++ b/apps/frontend/src/styles/layout.css
@@ -230,7 +230,12 @@
   border-radius: 10px;
   background: var(--bg);
 }
-.search-bar svg {
+/*
+  Only the leading icon of the field is muted, hence the direct-child selector:
+  the submit's icon is nested in the button and must inherit its white, which a
+  bare `.search-bar svg` would beat.
+*/
+.search-bar > svg {
   color: var(--muted);
 }
 .search-bar input {
@@ -243,12 +248,13 @@
   /* 16px: iOS Safari zooms the viewport on focus below this size. */
   font-size: 16px;
 }
+/* Submit of a search bar: a primary action, so it carries the accent fill. */
 .search-bar button {
   height: 36px;
   padding: 0 15px;
   border: 0;
   border-radius: 7px;
-  background: var(--accent-solid);
+  background: var(--accent-gradient);
   color: white;
   font-size: 12px;
   cursor: pointer;


### PR DESCRIPTION
## Summary

Tags created in `/admin` never appeared on the site, and no tag could be attached to a link from `/veille`.

The backend was not at fault. The `tags` relationship on the `bookmarks` collection, the migration and the `bookmarks_rels` join table all persist and re-read correctly — verified through the Payload local API, which wrote and read back a relation successfully.

The cause was two frontend gaps that formed a deadlock:

- the composer posted only the URL and silently dropped any tag selection
- the filter row listed only tags already carried by a bookmark

So no link could be tagged, and therefore no tag could ever surface.

## Changes

- **`src/lib/tags.ts`** (new) — cached read of the full tag vocabulary
- **`src/lib/bookmarks.ts`** — `BookmarkView` now exposes `tagIds` so editors know the current selection
- **`_components/tag-selector.tsx`** (new) — shared controlled chip list used by both editors
- **`_components/bookmark-composer.tsx`** — sends the selected tags when creating a link
- **`_components/card-tag-editor.tsx`** (new) — per-card popover that `PATCH`es the bookmark, with optimistic update and rollback on failure
- **`src/lib/content-cache.ts`** — `cachedRead` takes an explicit cache key

### Two deliberate design decisions

**Editors list every tag, the filter row lists only tags in use.** A freshly created tag must be reachable from an editor, otherwise the deadlock returns. But a filter that matches nothing has no value, so the filter row is unchanged.

**Links with no tag stay visible under "Tous"** — the grid filtering logic is untouched.

### One incidental fix

`cachedRead` keyed its `unstable_cache` entries by their *invalidation tag*. Adding a second reader under `CONTENT_TAGS.bookmarks` would have made the two reads overwrite each other's cache entries. Key (identity) and tag (invalidation) are now separate parameters, and all 5 call sites pass an explicit key.

### Markup note

The card is a single `<a>`. The editor trigger is anchored as a sibling *outside* the link — a `<button>` nested in an anchor is invalid markup, and every click would navigate instead of opening the popover.

## Follow-up: the trigger was invisible

Once the feature worked, nothing appeared to change on the page. The editor
trigger was hidden behind `opacity: 0` and only revealed on card hover — a
control nobody can find does not exist, and on touch there is no hover at all,
so it was unreachable outright.

It is now fully opaque at rest. An intermediate `opacity: 0.55` was tried first
and dropped: any opacity blends the accent fill into the card behind it, and the
button then read as a washed-out violet next to the site's other buttons.

For the record, the empty filter row was **not** a bug: the database holds 1 tag
and 3 links but 0 relations, and the filter row only lists tags a link actually
carries. It fills in as soon as a link is tagged.

Styling stays in plain CSS (`_styles.css`), per the project convention that
Tailwind is reserved for the main theme.

## Test plan

Automated, all green on this branch:

- [x] `pnpm type-check --filter @portfolio/frontend`
- [x] `pnpm lint --filter @portfolio/frontend`
- [x] `pnpm test` — 52 tests passing
- [x] `pnpm build --filter @portfolio/frontend`
- [x] CI green on this branch (lint, types, unit, build, E2E, CodeQL, GitGuardian)

Verified in the browser as a signed-out visitor:

- [x] `/veille` returns 200 and renders
- [x] no composer and no card tag editor in the markup (owner-only controls correctly absent)
- [x] no server errors, no console errors
- [x] trigger renders at 26x26 anchored top-right, fully opaque at rest

## Follow-up: every accent surface now comes from one token

Reviewing the tag editor against the site's primary buttons showed they did not
match, and the reason was structural rather than local: each accent surface
redeclared its own fill. `.button-primary` carried a gradient, `.search-bar
button` and the tag editor were flat `--accent-solid`, and the chat submit used
a third ramp of its own.

`--accent-gradient` and `--accent-glow` now live in `globals.css` and every one
of those surfaces points at them, so the fill is defined once. The chat submit's
slightly different ramp (`145deg, #376ee8 -> #7948e8`) was folded into the shared
one — the only intentional visual change beyond the fixes below.

Auditing those surfaces surfaced two real rendering bugs:

- **The composer's submit icon rendered muted, not white.** `.search-bar svg`
  matched the icon nested inside the button and beat the colour it inherits from
  it. Scoping that rule to the field's own icon (`.search-bar > svg`) leaves the
  submit icon white.
- **Project thumbnails were blank in light mode.** `--orb-a` and `--orb-b` were
  referenced by `.project-visual::before/::after` but defined nowhere, so both
  orbs were transparent, the thumbnail had no ground, and the fallback title
  rendered white on a white card. It only looked fine in dark mode by accident.
  Both tokens are now defined per theme, and the thumbnail gets an accent ground
  since the orbs are round and blurred and leave the corners bare on their own.

Contrast was measured against all three stops of the ramp: **4.52 / 6.12 /
5.01**. White labels and the fallback title stay above the 4.5:1 AA threshold
across the whole gradient, in both themes.

## Owner-session validation (done)

Confirmed with a signed-in session:

- [x] checking a chip in the composer creates a link carrying that tag
- [x] the card popover saves and the row lands in `bookmarks_rels`
- [x] the filter row picks up a tag as soon as one link carries it
- [x] a link added with no tag selected still appears under "Tous"

Closes #33

