### PR TITLE
feat(frontend): wire the hero chat to a real AI assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,14 @@ NEXT_PUBLIC_SERVER_URL="http://localhost:3000"
 # Mot de passe de la base PostgreSQL auto-hébergée (docker-compose.yml uniquement).
 # Générez-le avec : openssl rand -base64 24
 POSTGRES_PASSWORD=""
+
+# Clé API Groq, utilisée par l'assistant IA de l'accueil.
+# Générez-la sur https://console.groq.com/keys (offre gratuite suffisante).
+# Sans clé, la route /api/chat répond son message de repli au lieu d'échouer :
+# le site reste donc fonctionnel si vous ne configurez pas l'assistant.
+GROQ_API_KEY=""
+
+# Fournisseur d'IA à utiliser. Seul « groq » est implémenté à ce jour ;
+# la variable existe pour en brancher un autre sans toucher au code appelant.
+# Laissée vide, la valeur par défaut « groq » s'applique.
+AI_PROVIDER=""

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -13,3 +13,10 @@ DATABASE_URI=""
 
 # URL publique de l'application, utilisée par Payload pour les liens absolus.
 NEXT_PUBLIC_SERVER_URL="http://localhost:3000"
+
+# Clé API Groq pour l'assistant IA (https://console.groq.com/keys).
+# Absente, l'assistant affiche son message de repli et le site reste utilisable.
+GROQ_API_KEY=""
+
+# Fournisseur d'IA. Seul « groq » est implémenté ; vide = « groq ».
+AI_PROVIDER=""

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -36,7 +36,8 @@
     "payload": "^3.88.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15",

--- a/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
+++ b/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
@@ -4,7 +4,14 @@ import { ArrowRight, Send, Sparkles } from 'lucide-react'
 import { AnimatePresence, m, useScroll, useTransform } from 'motion/react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useImperativeHandle, useRef, useState, type FormEvent, type RefObject } from 'react'
+import {
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type FormEvent,
+  type RefObject,
+} from 'react'
 
 import { HOME_CONTENT } from '@/app/(site)/(home)/_content'
 import { EASE_OUT_QUINT, Stagger, StaggerItem } from '@/components/motion/primitives'
@@ -15,6 +22,8 @@ import { AvailabilityBadge } from './availability-badge'
 import type { HomeAvailability } from './types'
 
 const { hero, chat } = HOME_CONTENT
+
+const FOLLOW_TAIL_THRESHOLD = 80
 
 export interface HeroChatHandle {
   /** Scrolls to the chat input and focuses it, prefilling it when given a question. */
@@ -32,12 +41,29 @@ interface HeroProps {
 export function Hero({ role, location, availability, chatRef, onStartChat }: HeroProps) {
   const heroRef = useRef<HTMLElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const threadRef = useRef<HTMLDivElement>(null)
   const [question, setQuestion] = useState('')
   const { turns, streaming, pending, error, ask } = useAssistant()
 
   // The scripted exchange is the empty state: it shows what the chat is for.
   // The moment a real question lands it steps aside for the conversation.
   const started = turns.length > 0
+
+  // The transcript is bounded and scrollable, so new tokens would otherwise
+  // stream in below the fold. Following the tail keeps the answer in view while
+  // it is written, which is the only moment the visitor cares about.
+  useEffect(() => {
+    const thread = threadRef.current
+    if (!thread) return
+
+    // Someone who scrolled up is reading an earlier turn; yanking them back to
+    // the bottom on every token would make that impossible.
+    const distanceFromBottom = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+    if (distanceFromBottom > FOLLOW_TAIL_THRESHOLD) return
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    thread.scrollTo({ top: thread.scrollHeight, behavior: reduceMotion ? 'auto' : 'smooth' })
+  }, [turns, streaming, pending])
 
   useImperativeHandle(chatRef, () => ({
     ask(prefill) {
@@ -192,7 +218,7 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
 
           {/* The live conversation. `aria-live` is polite so a screen reader
               announces the finished answer without interrupting on every token. */}
-          <div className="chat-thread" aria-live="polite" aria-busy={pending}>
+          <div className="chat-thread" ref={threadRef} aria-live="polite" aria-busy={pending}>
             {turns.map((turn, index) =>
               turn.role === 'user' ? (
                 <m.div

--- a/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
+++ b/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
@@ -8,6 +8,7 @@ import { useImperativeHandle, useRef, useState, type FormEvent, type RefObject }
 
 import { HOME_CONTENT } from '@/app/(site)/(home)/_content'
 import { EASE_OUT_QUINT, Stagger, StaggerItem } from '@/components/motion/primitives'
+import { useAssistant } from '@/hooks/use-assistant'
 
 import { AvailabilityBadge } from './availability-badge'
 
@@ -32,7 +33,11 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
   const heroRef = useRef<HTMLElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const [question, setQuestion] = useState('')
-  const [answer, setAnswer] = useState('')
+  const { turns, streaming, pending, error, ask } = useAssistant()
+
+  // The scripted exchange is the empty state: it shows what the chat is for.
+  // The moment a real question lands it steps aside for the conversation.
+  const started = turns.length > 0
 
   useImperativeHandle(chatRef, () => ({
     ask(prefill) {
@@ -55,8 +60,8 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
 
   function submitQuestion(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (!question.trim()) return
-    setAnswer(chat.cannedAnswer)
+    if (!question.trim() || pending) return
+    void ask(question)
     setQuestion('')
   }
 
@@ -162,35 +167,91 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
             </span>
             <small>{chat.status}</small>
           </div>
-          <m.div
-            className="message message-user"
-            initial={{ opacity: 0, y: 14, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            transition={{ duration: 0.45, delay: 0.32, ease: EASE_OUT_QUINT }}
-          >
-            {chat.userMessage}
-          </m.div>
-          <m.div
-            className="message-row"
-            initial={{ opacity: 0, y: 14, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            // Holds the LCP element: kept early so the paint is not animation-gated.
-            transition={{ duration: 0.45, delay: 0.45, ease: EASE_OUT_QUINT }}
-          >
-            <span className="avatar">A</span>
-            <div className="message message-ai">{chat.aiMessage}</div>
-          </m.div>
+          {started ? null : (
+            <>
+              <m.div
+                className="message message-user"
+                initial={{ opacity: 0, y: 14, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                transition={{ duration: 0.45, delay: 0.32, ease: EASE_OUT_QUINT }}
+              >
+                {chat.userMessage}
+              </m.div>
+              <m.div
+                className="message-row"
+                initial={{ opacity: 0, y: 14, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                // Holds the LCP element: kept early so the paint is not animation-gated.
+                transition={{ duration: 0.45, delay: 0.45, ease: EASE_OUT_QUINT }}
+              >
+                <span className="avatar">A</span>
+                <div className="message message-ai">{chat.aiMessage}</div>
+              </m.div>
+            </>
+          )}
+
+          {/* The live conversation. `aria-live` is polite so a screen reader
+              announces the finished answer without interrupting on every token. */}
+          <div className="chat-thread" aria-live="polite" aria-busy={pending}>
+            {turns.map((turn, index) =>
+              turn.role === 'user' ? (
+                <m.div
+                  // Turns are append-only, so the index is a stable identity here.
+                  key={`user-${index}`}
+                  className="message message-user"
+                  initial={{ opacity: 0, y: 12, scale: 0.97 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
+                >
+                  {turn.content}
+                </m.div>
+              ) : (
+                <m.div
+                  key={`assistant-${index}`}
+                  className="message-row"
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
+                >
+                  <span className="avatar">A</span>
+                  <div className="message message-ai">{turn.content}</div>
+                </m.div>
+              )
+            )}
+
+            {streaming ? (
+              <div className="message-row">
+                <span className="avatar">A</span>
+                <div className="message message-ai">{streaming}</div>
+              </div>
+            ) : null}
+
+            {/* Shown only before the first token: once text flows, it is the
+                progress indicator. */}
+            {pending && !streaming ? (
+              <div className="message-row">
+                <span className="avatar">A</span>
+                <div className="message message-ai chat-typing" role="status">
+                  <span />
+                  <span />
+                  <span />
+                  <span className="sr-only">Réponse en cours</span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
           <AnimatePresence>
-            {answer ? (
+            {error ? (
               <m.p
-                className="chat-answer"
-                role="status"
+                className="chat-error"
+                role="alert"
                 initial={{ opacity: 0, y: 10, height: 0 }}
                 animate={{ opacity: 1, y: 0, height: 'auto' }}
                 exit={{ opacity: 0, height: 0 }}
                 transition={{ duration: 0.4, ease: EASE_OUT_QUINT }}
               >
-                {answer}
+                {error}
               </m.p>
             ) : null}
           </AnimatePresence>
@@ -211,7 +272,7 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
               onChange={(event) => setQuestion(event.target.value)}
               placeholder={chat.inputPlaceholder}
             />
-            <button type="submit" aria-label={chat.submitLabel}>
+            <button type="submit" aria-label={chat.submitLabel} disabled={pending}>
               <Send size={15} />
             </button>
           </m.form>

--- a/apps/frontend/src/app/(site)/(home)/_content.ts
+++ b/apps/frontend/src/app/(site)/(home)/_content.ts
@@ -23,8 +23,6 @@ export const HOME_CONTENT = {
     inputLabel: 'Posez votre question',
     inputPlaceholder: 'Posez votre question…',
     submitLabel: 'Envoyer',
-    cannedAnswer:
-      'Je peux te parler de mes projets, de mon approche frontend ou de la façon dont j’utilise Next.js.',
   },
   features: {
     heading: 'Découvrez mes fonctionnalités',

--- a/apps/frontend/src/app/(site)/(home)/_styles.css
+++ b/apps/frontend/src/app/(site)/(home)/_styles.css
@@ -158,8 +158,15 @@
   right: -28px;
   bottom: 4px;
   z-index: 4;
+  display: flex;
   width: min(100%, 550px);
   min-height: 260px;
+  /* The card is anchored on `bottom` and out of flow, so it grows upwards as
+     turns are appended and nothing can push the page down to make room. A fixed
+     ceiling keeps it inside its container; the transcript takes whatever height
+     is left once the header and the form have taken theirs. */
+  max-height: 520px;
+  flex-direction: column;
   padding: 24px;
   border: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
   border-radius: 20px;
@@ -171,6 +178,8 @@
 }
 .chat-header {
   display: flex;
+  /* Header and form are fixed furniture: only the transcript may be compressed. */
+  flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
@@ -206,6 +215,9 @@
 }
 .message {
   width: fit-content;
+  /* The card is a flex column now; a message must keep its natural height
+     rather than be compressed to make room. */
+  flex: 0 0 auto;
   max-width: 86%;
   border-radius: 12px;
   padding: 12px 15px;
@@ -219,6 +231,7 @@
 }
 .message-row {
   display: flex;
+  flex: 0 0 auto;
   align-items: flex-start;
   gap: 13px;
   margin-top: 16px;
@@ -242,13 +255,26 @@
 /* The live conversation, below the scripted example. */
 .chat-thread {
   display: flex;
+  /* The one scroll container of the card. `min-height: 0` is what actually
+     enables it: a flex child defaults to `min-height: auto`, which refuses to
+     shrink below its content and would push the overflow back out of the card. */
+  min-height: 0;
+  flex: 1 1 auto;
   flex-direction: column;
+  /* `auto` rather than `scroll`: the short conversations that fit show no track,
+     and the scripted empty state keeps its original look. */
+  overflow-y: auto;
+  /* Keeps a wheel gesture inside the transcript from continuing into the page
+     once the thread hits its end. */
+  overscroll-behavior: contain;
   /* An empty thread must not push the form down, so the gap only applies
      between children that actually exist. */
   gap: 16px;
 }
 .chat-thread:not(:empty) {
   margin-top: 16px;
+  /* Keeps the scrollbar off the text once the transcript overflows. */
+  padding-right: 4px;
 }
 .chat-thread .message-row {
   margin-top: 0;
@@ -300,6 +326,7 @@
   font-size: 12px;
 }
 .chat-form {
+  flex: 0 0 auto;
   display: flex;
   gap: 9px;
   margin-top: 20px;

--- a/apps/frontend/src/app/(site)/(home)/_styles.css
+++ b/apps/frontend/src/app/(site)/(home)/_styles.css
@@ -239,7 +239,60 @@
   padding: 0;
   color: var(--text);
 }
-.chat-answer {
+/* The live conversation, below the scripted example. */
+.chat-thread {
+  display: flex;
+  flex-direction: column;
+  /* An empty thread must not push the form down, so the gap only applies
+     between children that actually exist. */
+  gap: 16px;
+}
+.chat-thread:not(:empty) {
+  margin-top: 16px;
+}
+.chat-thread .message-row {
+  margin-top: 0;
+}
+/* Shown between the question and the first token, so the wait reads as
+   activity rather than a frozen interface. */
+.chat-typing {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 40px;
+}
+.chat-typing span:not(.sr-only) {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-solid);
+  animation: chat-typing 1.2s ease-in-out infinite;
+}
+.chat-typing span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.chat-typing span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes chat-typing {
+  0%,
+  60%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-typing span:not(.sr-only) {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+.chat-error {
   margin: 12px 0 0 45px;
   padding: 10px 12px;
   border-left: 2px solid var(--accent);

--- a/apps/frontend/src/app/(site)/api/chat/route.ts
+++ b/apps/frontend/src/app/(site)/api/chat/route.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod'
+
+import { ProviderError, resolveProvider } from '@/lib/ai'
+import { buildContext, getAssistantConfig } from '@/lib/assistant-context'
+
+import type { ChatMessage } from '@/lib/ai'
+
+/**
+ * Public endpoint behind the hero chat.
+ *
+ * It streams plain text rather than JSON events: the client appends what it
+ * receives, so there is no protocol to keep in sync on both sides.
+ *
+ * A static segment wins over Payload's `/api/[...slug]` catch-all, so this path
+ * is ours without any routing configuration.
+ */
+
+/** Dynamic by nature: every question is different and nothing here is cacheable. */
+export const dynamic = 'force-dynamic'
+
+/** Long enough for a full answer, short enough to release a stuck worker. */
+export const maxDuration = 30
+
+/**
+ * Bounds are validation, not politeness: the question is concatenated into a
+ * prompt billed by the token, and the history is replayed on every turn.
+ */
+const MAX_QUESTION_LENGTH = 1_000
+const MAX_HISTORY_TURNS = 8
+
+const requestSchema = z.object({
+  question: z.string().trim().min(1, 'Question vide').max(MAX_QUESTION_LENGTH),
+  /**
+   * Prior turns, sent by the client because the server keeps no session. They are
+   * capped and re-validated: this is visitor input like any other, and a caller
+   * could otherwise smuggle in an arbitrary system message.
+   */
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string().trim().min(1).max(MAX_QUESTION_LENGTH),
+      })
+    )
+    .max(MAX_HISTORY_TURNS)
+    .optional(),
+})
+
+/** Plain-text stream, marked no-store so no proxy replays one visitor's answer to another. */
+const streamHeaders = {
+  'Content-Type': 'text/plain; charset=utf-8',
+  'Cache-Control': 'no-store',
+  'X-Accel-Buffering': 'no',
+} as const
+
+/**
+ * Answers with the editable fallback and HTTP 200.
+ *
+ * 200 rather than 503 because this *is* the answer as far as the visitor is
+ * concerned: the chat shows a sentence explaining the assistant is unreachable,
+ * which the client handles as content, not as a failure to report.
+ */
+const fallbackResponse = (message: string): Response =>
+  new Response(message, { status: 200, headers: streamHeaders })
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return Response.json({ error: 'Corps de requête invalide' }, { status: 400 })
+  }
+
+  const parsed = requestSchema.safeParse(payload)
+  if (!parsed.success) {
+    return Response.json({ error: 'Question invalide' }, { status: 400 })
+  }
+
+  const settings = await getAssistantConfig()
+  if (!settings.enabled) return fallbackResponse(settings.unavailableMessage)
+
+  let provider
+  try {
+    provider = resolveProvider()
+  } catch {
+    // An unknown provider name is a misconfiguration; the visitor still gets a
+    // sentence rather than a stack trace.
+    return fallbackResponse(settings.unavailableMessage)
+  }
+  if (!provider) return fallbackResponse(settings.unavailableMessage)
+
+  const context = await buildContext()
+
+  const messages: ChatMessage[] = [
+    { role: 'system', content: `${settings.systemPrompt}\n\n# Contexte\n\n${context}` },
+    ...(parsed.data.history ?? []),
+    { role: 'user', content: parsed.data.question },
+  ]
+
+  const encoder = new TextEncoder()
+  let started = false
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const delta of provider.streamCompletion({
+          model: settings.model,
+          messages,
+          signal: request.signal,
+        })) {
+          started = true
+          controller.enqueue(encoder.encode(delta))
+        }
+      } catch (error) {
+        if (request.signal.aborted) {
+          // The visitor navigated away: nothing left to tell anyone.
+          controller.close()
+          return
+        }
+
+        const kind = error instanceof ProviderError ? error.kind : 'unavailable'
+        console.error(`[assistant] ${kind}:`, error)
+
+        // Once tokens are out, the fallback can only be appended — replacing the
+        // text would need a protocol the client does not speak. A half answer
+        // followed by the notice still beats a sentence cut mid-word.
+        const notice = started ? `\n\n${settings.unavailableMessage}` : settings.unavailableMessage
+        controller.enqueue(encoder.encode(notice))
+      }
+      controller.close()
+    },
+  })
+
+  return new Response(stream, { status: 200, headers: streamHeaders })
+}

--- a/apps/frontend/src/cms/collections/ai-knowledge.ts
+++ b/apps/frontend/src/cms/collections/ai-knowledge.ts
@@ -1,0 +1,91 @@
+import { CONTENT_TAGS, revalidateCollection } from '@/lib/content-cache'
+
+import type { CollectionConfig } from 'payload'
+
+const { afterChange, afterDelete } = revalidateCollection(CONTENT_TAGS.aiKnowledge)
+
+/**
+ * Curated answers the assistant is allowed to give about Adem.
+ *
+ * The rest of the CMS is public by definition — it is what the site displays.
+ * This collection is the opposite: it holds what the assistant may say but no
+ * page shows, so `read` is restricted to the signed-in admin. The context
+ * builder reads it with `overrideAccess: true` on the server, which is the only
+ * place that is legitimate: the entries reach visitors as generated prose, never
+ * as an API response.
+ *
+ * `published` gates an entry without deleting it: a half-written answer stays in
+ * `/admin` while remaining invisible to the model.
+ */
+const AIKnowledge: CollectionConfig = {
+  slug: 'ai-knowledge',
+  labels: {
+    singular: 'Connaissance IA',
+    plural: 'Connaissances IA',
+  },
+  admin: {
+    useAsTitle: 'question',
+    defaultColumns: ['question', 'category', 'published'],
+    description:
+      'Réponses que l’assistant peut donner sur Adem. Ce contenu n’est jamais affiché sur le site et n’est pas exposé publiquement.',
+  },
+  access: {
+    // Private by design: everything here feeds the model, nothing here is a page.
+    read: ({ req }) => Boolean(req.user),
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+    delete: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'question',
+      type: 'text',
+      label: 'Question',
+      required: true,
+      admin: {
+        description: 'La question telle qu’un visiteur la poserait.',
+      },
+    },
+    {
+      name: 'answer',
+      type: 'textarea',
+      label: 'Réponse',
+      required: true,
+      admin: {
+        description: 'Ce que l’assistant doit répondre. Écrit à la troisième personne.',
+      },
+    },
+    {
+      name: 'category',
+      type: 'select',
+      label: 'Catégorie',
+      defaultValue: 'parcours',
+      options: [
+        { label: 'Parcours', value: 'parcours' },
+        { label: 'Compétences', value: 'competences' },
+        { label: 'Méthode de travail', value: 'methode' },
+        { label: 'Collaboration', value: 'collaboration' },
+        { label: 'Autre', value: 'autre' },
+      ],
+      admin: {
+        description: 'Sert à regrouper les entrées dans le contexte envoyé au modèle.',
+      },
+    },
+    {
+      name: 'published',
+      type: 'checkbox',
+      label: 'Publiée',
+      defaultValue: true,
+      admin: {
+        position: 'sidebar',
+        description: 'Décochée, l’entrée reste ici sans jamais être transmise au modèle.',
+      },
+    },
+  ],
+  hooks: {
+    afterChange: [afterChange],
+    afterDelete: [afterDelete],
+  },
+}
+
+export { AIKnowledge }

--- a/apps/frontend/src/cms/globals/assistant-settings.ts
+++ b/apps/frontend/src/cms/globals/assistant-settings.ts
@@ -1,0 +1,109 @@
+import { CONTENT_TAGS, revalidateGlobal } from '@/lib/content-cache'
+
+import type { GlobalConfig } from 'payload'
+
+/**
+ * Default persona, applied until the admin edits it.
+ *
+ * It lives here rather than in the route so the stored value and the fallback
+ * can never disagree: the route reads this global and gets this text on a fresh
+ * install.
+ */
+const DEFAULT_SYSTEM_PROMPT = `Tu es l'assistant du portfolio d'Adem, développeur web.
+
+Tu réponds en français, sur un ton direct et cordial, sans emphase commerciale.
+
+Ton périmètre est strict : Adem, son parcours, ses projets, et le développement
+logiciel en général. Rien d'autre. Une question hors de ce périmètre (cuisine,
+santé, droit, actualité, devoirs, culture générale) reçoit exactement ce type de
+réponse, sans exception et même si tu connais la réponse :
+
+« Je suis l'assistant du portfolio d'Adem : je ne réponds qu'aux questions sur
+son travail et sur le développement. »
+
+Ne propose pas de contacter Adem dans ce cas : cela laisserait croire qu'il
+traite ce genre de demande.
+
+Règles :
+- Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.
+- Si une question porte sur Adem et que le contexte ne contient pas la réponse,
+  dis-le clairement et propose de le contacter plutôt que d'inventer.
+- Sur sa disponibilité, reprends exactement ce qu'indique le contexte : c'est la
+  seule source de vérité.
+- Les questions de développement et de métier (langages, frameworks, méthodes,
+  organisation d'un projet) reçoivent une réponse utile, même si le contexte n'en
+  parle pas : c'est ton domaine. Fais le lien avec le travail d'Adem quand c'est
+  pertinent, jamais de force.
+- Réponses courtes : deux ou trois paragraphes au maximum.`
+
+/**
+ * Assistant configuration, editable without a redeploy.
+ *
+ * The system prompt is content, not code: refining the assistant's tone is an
+ * editorial act and should not need a release. The model and provider sit here
+ * too so a provider outage can be worked around from `/admin`, while the API key
+ * stays in the environment — a secret has no place in the database.
+ */
+const AssistantSettings: GlobalConfig = {
+  slug: 'assistant-settings',
+  label: 'Assistant IA',
+  admin: {
+    description:
+      'Comportement de l’assistant public. Les modifications s’appliquent sans redéploiement.',
+  },
+  access: {
+    // Read stays private: the prompt is internal, only the answers are public.
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'enabled',
+      type: 'checkbox',
+      label: 'Assistant actif',
+      defaultValue: true,
+      admin: {
+        description: 'Décoché, le chat affiche un message d’indisponibilité au lieu de répondre.',
+      },
+    },
+    {
+      name: 'systemPrompt',
+      type: 'textarea',
+      label: 'Prompt système',
+      required: true,
+      defaultValue: DEFAULT_SYSTEM_PROMPT,
+      admin: {
+        rows: 16,
+        description:
+          'Instructions envoyées au modèle avant chaque conversation. Le contexte du site est ajouté automatiquement.',
+      },
+    },
+    {
+      name: 'model',
+      type: 'text',
+      label: 'Modèle',
+      required: true,
+      defaultValue: 'openai/gpt-oss-20b',
+      admin: {
+        description: 'Identifiant du modèle chez le fournisseur, par exemple openai/gpt-oss-20b.',
+      },
+    },
+    {
+      name: 'unavailableMessage',
+      type: 'textarea',
+      label: 'Message de repli',
+      required: true,
+      defaultValue:
+        'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.',
+      admin: {
+        description:
+          'Affiché en cas de panne du fournisseur, de quota épuisé ou d’assistant désactivé.',
+      },
+    },
+  ],
+  hooks: {
+    afterChange: [revalidateGlobal(CONTENT_TAGS.assistant)],
+  },
+}
+
+export { AssistantSettings, DEFAULT_SYSTEM_PROMPT }

--- a/apps/frontend/src/cms/migrations/20260818_141706_assistant.json
+++ b/apps/frontend/src/cms/migrations/20260818_141706_assistant.json
@@ -1,0 +1,2579 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_id": {
+          "name": "cover_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_url_idx": {
+          "name": "projects_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_idx": {
+          "name": "projects_cover_idx",
+          "columns": [
+            {
+              "expression": "cover_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_order_idx": {
+          "name": "projects_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_cover_id_media_id_fk": {
+          "name": "projects_cover_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": ["cover_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_texts": {
+      "name": "projects_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_texts_order_parent": {
+          "name": "projects_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_texts_parent_fk": {
+          "name": "projects_texts_parent_fk",
+          "tableFrom": "projects_texts",
+          "tableTo": "projects",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_achievements": {
+      "name": "experiences_achievements",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_achievements_order_idx": {
+          "name": "experiences_achievements_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_achievements_parent_id_idx": {
+          "name": "experiences_achievements_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_achievements_parent_id_fk": {
+          "name": "experiences_achievements_parent_id_fk",
+          "tableFrom": "experiences_achievements",
+          "tableTo": "experiences",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences": {
+      "name": "experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current": {
+          "name": "current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project": {
+          "name": "project",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "experiences_start_date_idx": {
+          "name": "experiences_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_updated_at_idx": {
+          "name": "experiences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_created_at_idx": {
+          "name": "experiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_texts": {
+      "name": "experiences_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiences_texts_order_parent": {
+          "name": "experiences_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_texts_parent_fk": {
+          "name": "experiences_texts_parent_fk",
+          "tableFrom": "experiences_texts",
+          "tableTo": "experiences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_url_idx": {
+          "name": "bookmarks_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_domain_idx": {
+          "name": "bookmarks_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_active_idx": {
+          "name": "bookmarks_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_updated_at_idx": {
+          "name": "bookmarks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_created_at_idx": {
+          "name": "bookmarks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks_rels": {
+      "name": "bookmarks_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_rels_order_idx": {
+          "name": "bookmarks_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_parent_idx": {
+          "name": "bookmarks_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_path_idx": {
+          "name": "bookmarks_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_tags_id_idx": {
+          "name": "bookmarks_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_rels_parent_fk": {
+          "name": "bookmarks_rels_parent_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_rels_tags_fk": {
+          "name": "bookmarks_rels_tags_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_knowledge": {
+      "name": "ai_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "enum_ai_knowledge_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'parcours'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_knowledge_updated_at_idx": {
+          "name": "ai_knowledge_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_knowledge_created_at_idx": {
+          "name": "ai_knowledge_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projects_id": {
+          "name": "projects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences_id": {
+          "name": "experiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarks_id": {
+          "name": "bookmarks_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_knowledge_id": {
+          "name": "ai_knowledge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_projects_id_idx": {
+          "name": "payload_locked_documents_rels_projects_id_idx",
+          "columns": [
+            {
+              "expression": "projects_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_experiences_id_idx": {
+          "name": "payload_locked_documents_rels_experiences_id_idx",
+          "columns": [
+            {
+              "expression": "experiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_bookmarks_id_idx": {
+          "name": "payload_locked_documents_rels_bookmarks_id_idx",
+          "columns": [
+            {
+              "expression": "bookmarks_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_knowledge_id_idx": {
+          "name": "payload_locked_documents_rels_ai_knowledge_id_idx",
+          "columns": [
+            {
+              "expression": "ai_knowledge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_projects_fk": {
+          "name": "payload_locked_documents_rels_projects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "projects",
+          "columnsFrom": ["projects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_experiences_fk": {
+          "name": "payload_locked_documents_rels_experiences_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "experiences",
+          "columnsFrom": ["experiences_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_bookmarks_fk": {
+          "name": "payload_locked_documents_rels_bookmarks_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmarks_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_knowledge_fk": {
+          "name": "payload_locked_documents_rels_ai_knowledge_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_knowledge",
+          "columnsFrom": ["ai_knowledge_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_identity": {
+      "name": "site_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_display_name": {
+          "name": "contact_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_role": {
+          "name": "contact_role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_location": {
+          "name": "contact_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_github_url": {
+          "name": "social_github_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_linkedin_url": {
+          "name": "social_linkedin_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_publisher": {
+          "name": "legal_publisher",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_name": {
+          "name": "legal_host_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_address": {
+          "name": "legal_host_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_data_policy": {
+          "name": "legal_data_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Disponible pour des opportunités'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_skill_groups": {
+      "name": "profile_skill_groups",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_skill_groups_order_idx": {
+          "name": "profile_skill_groups_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_skill_groups_parent_id_idx": {
+          "name": "profile_skill_groups_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_skill_groups_parent_id_fk": {
+          "name": "profile_skill_groups_parent_id_fk",
+          "tableFrom": "profile_skill_groups",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_principles": {
+      "name": "profile_principles",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_principles_order_idx": {
+          "name": "profile_principles_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_principles_parent_id_idx": {
+          "name": "profile_principles_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_principles_parent_id_fk": {
+          "name": "profile_principles_parent_id_fk",
+          "tableFrom": "profile_principles",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "headline": {
+          "name": "headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_texts": {
+      "name": "profile_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_texts_order_parent": {
+          "name": "profile_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_texts_parent_fk": {
+          "name": "profile_texts_parent_fk",
+          "tableFrom": "profile_texts",
+          "tableTo": "profile",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assistant_settings": {
+      "name": "assistant_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Tu es l''assistant du portfolio d''Adem, développeur web.\n\nTu réponds en français, sur un ton direct et cordial, sans emphase commerciale.\n\nRègles :\n- Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.\n- Si le contexte ne contient pas l''information, dis-le clairement et propose de\n  contacter Adem plutôt que d''inventer.\n- Sur sa disponibilité, reprends exactement ce qu''indique le contexte : c''est la\n  seule source de vérité.\n- Les questions générales (technique, métier) reçoivent une réponse utile ; fais\n  le lien avec le travail d''Adem quand c''est pertinent, jamais de force.\n- Réponses courtes : deux ou trois paragraphes au maximum.'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-oss-20b'"
+        },
+        "unavailable_message": {
+          "name": "unavailable_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_ai_knowledge_category": {
+      "name": "enum_ai_knowledge_category",
+      "schema": "public",
+      "values": ["parcours", "competences", "methode", "collaboration", "autre"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "a2878eca-e4bc-4d40-9885-bafb992283c2",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/apps/frontend/src/cms/migrations/20260818_141706_assistant.ts
+++ b/apps/frontend/src/cms/migrations/20260818_141706_assistant.ts
@@ -1,0 +1,56 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_ai_knowledge_category" AS ENUM('parcours', 'competences', 'methode', 'collaboration', 'autre');
+  CREATE TABLE "ai_knowledge" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"question" varchar NOT NULL,
+  	"answer" varchar NOT NULL,
+  	"category" "enum_ai_knowledge_category" DEFAULT 'parcours',
+  	"published" boolean DEFAULT true,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  CREATE TABLE "assistant_settings" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"enabled" boolean DEFAULT true,
+  	"system_prompt" varchar DEFAULT 'Tu es l''assistant du portfolio d''Adem, développeur web.
+  
+  Tu réponds en français, sur un ton direct et cordial, sans emphase commerciale.
+  
+  Règles :
+  - Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.
+  - Si le contexte ne contient pas l''information, dis-le clairement et propose de
+    contacter Adem plutôt que d''inventer.
+  - Sur sa disponibilité, reprends exactement ce qu''indique le contexte : c''est la
+    seule source de vérité.
+  - Les questions générales (technique, métier) reçoivent une réponse utile ; fais
+    le lien avec le travail d''Adem quand c''est pertinent, jamais de force.
+  - Réponses courtes : deux ou trois paragraphes au maximum.' NOT NULL,
+  	"model" varchar DEFAULT 'openai/gpt-oss-20b' NOT NULL,
+  	"unavailable_message" varchar DEFAULT 'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.' NOT NULL,
+  	"updated_at" timestamp(3) with time zone,
+  	"created_at" timestamp(3) with time zone
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "ai_knowledge_id" integer;
+  CREATE INDEX "ai_knowledge_updated_at_idx" ON "ai_knowledge" USING btree ("updated_at");
+  CREATE INDEX "ai_knowledge_created_at_idx" ON "ai_knowledge" USING btree ("created_at");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_ai_knowledge_fk" FOREIGN KEY ("ai_knowledge_id") REFERENCES "public"."ai_knowledge"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_ai_knowledge_id_idx" ON "payload_locked_documents_rels" USING btree ("ai_knowledge_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "ai_knowledge" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "assistant_settings" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "ai_knowledge" CASCADE;
+  DROP TABLE "assistant_settings" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_ai_knowledge_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_ai_knowledge_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "ai_knowledge_id";
+  DROP TYPE "public"."enum_ai_knowledge_category";`)
+}

--- a/apps/frontend/src/cms/migrations/index.ts
+++ b/apps/frontend/src/cms/migrations/index.ts
@@ -4,6 +4,7 @@ import * as migration_20260817_104541_bookmarks from './20260817_104541_bookmark
 import * as migration_20260817_124153_real_content from './20260817_124153_real_content'
 import * as migration_20260817_155900_display_name from './20260817_155900_display_name'
 import * as migration_20260818_135519_availability from './20260818_135519_availability'
+import * as migration_20260818_141706_assistant from './20260818_141706_assistant'
 
 export const migrations = [
   {
@@ -35,5 +36,10 @@ export const migrations = [
     up: migration_20260818_135519_availability.up,
     down: migration_20260818_135519_availability.down,
     name: '20260818_135519_availability',
+  },
+  {
+    up: migration_20260818_141706_assistant.up,
+    down: migration_20260818_141706_assistant.down,
+    name: '20260818_141706_assistant',
   },
 ]

--- a/apps/frontend/src/cms/payload.config.ts
+++ b/apps/frontend/src/cms/payload.config.ts
@@ -6,12 +6,14 @@ import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { buildConfig } from 'payload'
 import sharp from 'sharp'
 
+import { AIKnowledge } from './collections/ai-knowledge'
 import { Bookmarks } from './collections/bookmarks'
 import { Experiences } from './collections/experiences'
 import { Media } from './collections/media'
 import { Projects } from './collections/projects'
 import { Tags } from './collections/tags'
 import { Users } from './collections/users'
+import { AssistantSettings } from './globals/assistant-settings'
 import { Availability } from './globals/availability'
 import { Profile } from './globals/profile'
 import { SiteIdentity } from './globals/site-identity'
@@ -26,8 +28,8 @@ export default buildConfig({
       titleSuffix: '— Adem',
     },
   },
-  collections: [Users, Media, Projects, Experiences, Tags, Bookmarks],
-  globals: [SiteIdentity, Availability, Profile],
+  collections: [Users, Media, Projects, Experiences, Tags, Bookmarks, AIKnowledge],
+  globals: [SiteIdentity, Availability, Profile, AssistantSettings],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET ?? '',
   typescript: {

--- a/apps/frontend/src/hooks/use-assistant.ts
+++ b/apps/frontend/src/hooks/use-assistant.ts
@@ -1,0 +1,116 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+/**
+ * Drives the conversation with the public assistant.
+ *
+ * It owns the exchange — turns, streaming, errors, aborting — so the hero stays a
+ * view. The route streams plain text, so consuming it is a read loop with no
+ * protocol to decode.
+ */
+
+interface AssistantTurn {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+/** Turns kept and replayed to the server, which holds no session of its own. */
+const MAX_HISTORY_TURNS = 8
+
+const NETWORK_ERROR =
+  'La connexion a échoué. Vérifiez votre réseau et réessayez, ou contactez-moi directement.'
+
+interface UseAssistantResult {
+  turns: AssistantTurn[]
+  /** Text streaming in right now; empty once the turn is complete. */
+  streaming: string
+  pending: boolean
+  error: string | null
+  ask: (question: string) => Promise<void>
+  reset: () => void
+}
+
+const useAssistant = (): UseAssistantResult => {
+  const [turns, setTurns] = useState<AssistantTurn[]>([])
+  const [streaming, setStreaming] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Held in a ref so a new question can cancel the one still streaming without
+  // re-rendering on every keystroke.
+  const abortRef = useRef<AbortController | null>(null)
+
+  const ask = useCallback(
+    async (question: string) => {
+      const trimmed = question.trim()
+      if (!trimmed) return
+
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      setError(null)
+      setPending(true)
+      setStreaming('')
+
+      // The question is appended before the call so it appears instantly; the
+      // history sent along is the state before it, which is what the model needs.
+      const history = turns.slice(-MAX_HISTORY_TURNS)
+      setTurns((current) => [...current, { role: 'user', content: trimmed }])
+
+      try {
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question: trimmed, history }),
+          signal: controller.signal,
+        })
+
+        if (!response.ok || !response.body) {
+          setError(NETWORK_ERROR)
+          return
+        }
+
+        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader()
+        let answer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          answer += value
+          setStreaming(answer)
+        }
+
+        // Moved into the turn list in one step, so the answer never flickers
+        // between the streaming buffer and its final position.
+        setTurns((current) => [...current, { role: 'assistant', content: answer }])
+        setStreaming('')
+      } catch (cause) {
+        // An abort is a deliberate cancellation, not a failure to report.
+        if (cause instanceof DOMException && cause.name === 'AbortError') return
+        setError(NETWORK_ERROR)
+      } finally {
+        // A superseded request must not clear the flag of the one that replaced it.
+        if (abortRef.current === controller) {
+          setPending(false)
+          abortRef.current = null
+        }
+      }
+    },
+    [turns]
+  )
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort()
+    abortRef.current = null
+    setTurns([])
+    setStreaming('')
+    setPending(false)
+    setError(null)
+  }, [])
+
+  return { turns, streaming, pending, error, ask, reset }
+}
+
+export { useAssistant, type AssistantTurn }

--- a/apps/frontend/src/lib/ai/groq.test.ts
+++ b/apps/frontend/src/lib/ai/groq.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createGroqProvider, GROQ_ENDPOINT } from './groq'
+import { ProviderError } from './provider'
+
+/**
+ * The provider is the one place that touches a third party, so these tests pin
+ * down the two things the route depends on: what a stream yields, and which
+ * `kind` a failure carries — the route picks its fallback from that kind alone.
+ *
+ * `fetch` is stubbed rather than hitting Groq: a test suite that needs an API key
+ * and a network is a test suite that gets skipped.
+ */
+
+/** Builds a response whose body streams the given SSE frames. */
+const sseResponse = (frames: string[]): Response => {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder()
+      for (const frame of frames) controller.enqueue(encoder.encode(frame))
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200 })
+}
+
+const dataFrame = (content: string): string =>
+  `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n`
+
+const collect = async (provider = createGroqProvider('test-key')): Promise<string[]> => {
+  const chunks: string[] = []
+  for await (const chunk of provider.streamCompletion({
+    model: 'openai/gpt-oss-20b',
+    messages: [{ role: 'user', content: 'Bonjour' }],
+  })) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('createGroqProvider — flux', () => {
+  it('restitue les deltas dans l’ordre', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(sseResponse([dataFrame('Bon'), dataFrame('jour'), 'data: [DONE]\n']))
+      )
+    )
+
+    expect(await collect()).toEqual(['Bon', 'jour'])
+  })
+
+  it('ignore les lignes vides et le sentinel de fin', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(sseResponse(['\n', dataFrame('Salut'), '\n', 'data: [DONE]\n', '\n']))
+      )
+    )
+
+    expect(await collect()).toEqual(['Salut'])
+  })
+
+  it('recolle une trame coupée entre deux paquets réseau', async () => {
+    // A chunk boundary can fall anywhere, including mid-JSON: the buffer has to
+    // hold the partial line until the rest arrives.
+    const frame = dataFrame('Disponible')
+    const cut = Math.floor(frame.length / 2)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(sseResponse([frame.slice(0, cut), frame.slice(cut), 'data: [DONE]\n']))
+      )
+    )
+
+    expect(await collect()).toEqual(['Disponible'])
+  })
+
+  it('ignore une trame au JSON invalide sans interrompre le flux', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(sseResponse([dataFrame('a'), 'data: {oops\n', dataFrame('b')])))
+    )
+
+    expect(await collect()).toEqual(['a', 'b'])
+  })
+
+  it('ignore une trame sans contenu (rôle seul, arrêt)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          sseResponse([
+            `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] })}\n`,
+            dataFrame('Texte'),
+            `data: ${JSON.stringify({ choices: [{ finish_reason: 'stop' }] })}\n`,
+          ])
+        )
+      )
+    )
+
+    expect(await collect()).toEqual(['Texte'])
+  })
+
+  it('envoie la clé et demande le streaming', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(sseResponse(['data: [DONE]\n'])))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await collect(createGroqProvider('secret-key'))
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe(GROQ_ENDPOINT)
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secret-key')
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      model: 'openai/gpt-oss-20b',
+      stream: true,
+    })
+  })
+})
+
+describe('createGroqProvider — erreurs', () => {
+  /**
+   * The route maps `kind` to a user-facing outcome, so a wrong classification is
+   * a wrong message: a quota hit must never read as a bad request.
+   */
+  it.each([
+    [429, 'quota'],
+    [402, 'quota'],
+    [500, 'unavailable'],
+    [503, 'unavailable'],
+    [400, 'bad_request'],
+    [401, 'bad_request'],
+  ])('classe le statut %i en « %s »', async (status, kind) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('refus', { status })))
+    )
+
+    await expect(collect()).rejects.toMatchObject({ kind })
+  })
+
+  it('signale une panne réseau comme indisponibilité', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('fetch failed')))
+    )
+
+    const error = await collect().catch((cause: unknown) => cause)
+    expect(error).toBeInstanceOf(ProviderError)
+    expect(error).toMatchObject({ kind: 'unavailable' })
+  })
+
+  it('propage l’annulation du client sans la convertir en erreur fournisseur', async () => {
+    // A visitor leaving the page is not an outage: turning it into one would show
+    // a failure message to someone who is no longer there, and hide real ones.
+    const controller = new AbortController()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RequestInit) => {
+        controller.abort()
+        return Promise.reject(
+          Object.assign(new Error('aborted'), { name: 'AbortError', signal: init.signal })
+        )
+      })
+    )
+
+    const provider = createGroqProvider('test-key')
+    const run = async () => {
+      for await (const _chunk of provider.streamCompletion({
+        model: 'openai/gpt-oss-20b',
+        messages: [{ role: 'user', content: 'Bonjour' }],
+        signal: controller.signal,
+      })) {
+        // draining is enough: the throw happens before the first chunk
+      }
+    }
+
+    await expect(run()).rejects.not.toBeInstanceOf(ProviderError)
+  })
+})

--- a/apps/frontend/src/lib/ai/groq.ts
+++ b/apps/frontend/src/lib/ai/groq.ts
@@ -1,0 +1,132 @@
+import { ProviderError } from './provider'
+
+import type { ChatProvider, CompletionRequest } from './provider'
+
+/**
+ * Groq implementation of `ChatProvider`.
+ *
+ * Written against `fetch` rather than the vendor SDK: the surface used here is
+ * one POST and an SSE stream, and the whole point of `ChatProvider` is that this
+ * file stays replaceable. A dependency would add weight to the server bundle and
+ * a second abstraction on top of the one we already define.
+ */
+
+const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions'
+
+/**
+ * Groq is fast — first tokens usually land well under a second. Fifteen seconds
+ * is therefore not a normal wait but a signal that something is wrong, and the
+ * visitor gets the fallback instead of a spinner that never resolves.
+ */
+const REQUEST_TIMEOUT_MS = 15_000
+
+/** SSE terminator, per the OpenAI-compatible protocol Groq implements. */
+const STREAM_DONE = '[DONE]'
+
+/** Shape of the delta frames; every other field of the chunk is ignored. */
+interface StreamChunk {
+  choices?: { delta?: { content?: string | null } }[]
+}
+
+/**
+ * Maps an HTTP status to a failure kind.
+ *
+ * 429 and 402 mean the account hit its limits, which the issue calls out
+ * explicitly: it must read as "come back later", never as a broken page. 5xx is
+ * the provider being down. Anything else points at our own request.
+ */
+const kindForStatus = (status: number): ProviderError['kind'] => {
+  if (status === 429 || status === 402) return 'quota'
+  if (status >= 500) return 'unavailable'
+  return 'bad_request'
+}
+
+/** Reads one SSE `data:` line, returning the text delta it carries. */
+const readDelta = (line: string): string | null => {
+  if (!line.startsWith('data:')) return null
+
+  const payload = line.slice(5).trim()
+  if (payload === '' || payload === STREAM_DONE) return null
+
+  try {
+    const chunk = JSON.parse(payload) as StreamChunk
+    return chunk.choices?.[0]?.delta?.content ?? null
+  } catch {
+    // A truncated frame is not worth failing the whole answer over: the next
+    // chunk carries the rest, and dropping one delta degrades gracefully.
+    return null
+  }
+}
+
+const ignoreCancelError = (): void => undefined
+
+const createGroqProvider = (apiKey: string): ChatProvider => ({
+  id: 'groq',
+
+  async *streamCompletion({ model, messages, signal }: CompletionRequest) {
+    // Times the request out on our side while still honouring an upstream abort
+    // (the visitor navigating away), so a hung provider cannot pin the handler.
+    const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    const abort = signal ? AbortSignal.any([signal, timeout]) : timeout
+
+    let response: Response
+    try {
+      response = await fetch(GROQ_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ model, messages, stream: true }),
+        signal: abort,
+      })
+    } catch (error) {
+      // The caller's own abort is not a provider failure: let it propagate so the
+      // route can stay silent instead of showing an error to someone who left.
+      if (signal?.aborted) throw error
+      if (timeout.aborted) {
+        throw new ProviderError('timeout', 'Groq did not respond in time', { cause: error })
+      }
+      throw new ProviderError('unavailable', 'Groq is unreachable', { cause: error })
+    }
+
+    if (!response.ok || !response.body) {
+      // Read the body for the log only: a provider message must never reach the
+      // visitor, who gets the editable fallback instead.
+      const detail = await response.text().catch(() => '')
+      throw new ProviderError(
+        kindForStatus(response.status),
+        `Groq responded ${response.status}: ${detail.slice(0, 200)}`
+      )
+    }
+
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader()
+    // Frames are split across network chunks, so a partial line is kept until
+    // its newline arrives.
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += value
+        const lines = buffer.split('\n')
+        // The last element is either an incomplete line or an empty string.
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          const delta = readDelta(line)
+          if (delta) yield delta
+        }
+      }
+    } finally {
+      // Releases the connection when the consumer stops early, which happens on
+      // every abandoned page. A cancel that fails has nothing left to release,
+      // and must not mask the reason the loop exited.
+      await reader.cancel().catch(ignoreCancelError)
+    }
+  },
+})
+
+export { createGroqProvider, GROQ_ENDPOINT, REQUEST_TIMEOUT_MS }

--- a/apps/frontend/src/lib/ai/index.test.ts
+++ b/apps/frontend/src/lib/ai/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_PROVIDER, ProviderError, resolveProvider } from './index'
+
+/**
+ * `ProcessEnv` requires `NODE_ENV`, which none of these cases care about: this
+ * keeps the env literals readable without a cast on every call.
+ */
+const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
+
+/**
+ * Provider selection decides whether the assistant answers at all, so the
+ * distinction that matters here is between a missing key — a deployment state the
+ * route must survive by showing its fallback — and a bad configuration, which is
+ * a mistake worth surfacing loudly.
+ */
+describe('resolveProvider', () => {
+  it('retourne null sans clé, pour laisser la route répondre son message de repli', () => {
+    expect(resolveProvider(env({}))).toBeNull()
+  })
+
+  it('traite une clé vide ou blanche comme absente', () => {
+    expect(resolveProvider(env({ GROQ_API_KEY: '   ' }))).toBeNull()
+  })
+
+  it('choisit Groq par défaut quand la clé est là', () => {
+    const provider = resolveProvider(env({ GROQ_API_KEY: 'k' }))
+    expect(provider?.id).toBe(DEFAULT_PROVIDER)
+  })
+
+  it('accepte un fournisseur nommé explicitement', () => {
+    const provider = resolveProvider(env({ AI_PROVIDER: 'groq', GROQ_API_KEY: 'k' }))
+    expect(provider?.id).toBe('groq')
+  })
+
+  it('rejette un fournisseur inconnu au lieu de retomber silencieusement sur Groq', () => {
+    // Silently ignoring the variable would make a typo look like it worked.
+    expect(() => resolveProvider(env({ AI_PROVIDER: 'openai', GROQ_API_KEY: 'k' }))).toThrow(
+      ProviderError
+    )
+  })
+
+  it('rejette le fournisseur inconnu même sans clé', () => {
+    expect(() => resolveProvider(env({ AI_PROVIDER: 'mistral' }))).toThrow(ProviderError)
+  })
+})

--- a/apps/frontend/src/lib/ai/index.ts
+++ b/apps/frontend/src/lib/ai/index.ts
@@ -1,0 +1,46 @@
+import { createGroqProvider } from './groq'
+import { ProviderError } from './provider'
+
+import type { ChatProvider } from './provider'
+
+/**
+ * Resolves the configured provider.
+ *
+ * Selection lives in the environment rather than in the settings global, unlike
+ * the model name: picking a vendor is meaningless without its API key, and a key
+ * belongs in the environment, never in the database. Editing the provider from
+ * `/admin` would let someone select a vendor the server cannot authenticate to.
+ */
+
+type ProviderId = 'groq'
+
+const FACTORIES: Record<ProviderId, (apiKey: string) => ChatProvider> = {
+  groq: createGroqProvider,
+}
+
+const DEFAULT_PROVIDER: ProviderId = 'groq'
+
+const isProviderId = (value: string): value is ProviderId => value in FACTORIES
+
+/**
+ * Builds the provider from the environment, or `null` when it is not configured.
+ *
+ * `null` rather than a throw: a missing key is a deployment state, not a bug, and
+ * the route answers it with the fallback message. Throwing here would turn a
+ * portfolio without an AI key into a 500 on every question.
+ */
+const resolveProvider = (env: NodeJS.ProcessEnv = process.env): ChatProvider | null => {
+  const requested = (env.AI_PROVIDER ?? DEFAULT_PROVIDER).trim()
+  if (!isProviderId(requested)) {
+    throw new ProviderError('bad_request', `Unknown AI provider: ${requested}`)
+  }
+
+  const apiKey = env.GROQ_API_KEY?.trim()
+  if (!apiKey) return null
+
+  return FACTORIES[requested](apiKey)
+}
+
+export { DEFAULT_PROVIDER, resolveProvider }
+export { ProviderError } from './provider'
+export type { ChatMessage, ChatProvider, CompletionRequest, ProviderErrorKind } from './provider'

--- a/apps/frontend/src/lib/ai/provider.ts
+++ b/apps/frontend/src/lib/ai/provider.ts
@@ -1,0 +1,55 @@
+/**
+ * Provider-agnostic contract for the chat model.
+ *
+ * The route and the context builder depend on this interface alone, so swapping
+ * Groq for another vendor means adding a file next to `groq.ts` — nothing else
+ * moves. It is deliberately narrow: one streaming call, because that is all the
+ * assistant does.
+ */
+
+/** A conversation turn, in the shape every chat API expects. */
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+interface CompletionRequest {
+  model: string
+  messages: ChatMessage[]
+  /** Aborts the upstream call; the route turns this into the fallback message. */
+  signal?: AbortSignal
+}
+
+/**
+ * Why a call failed, in the terms the UI cares about.
+ *
+ * The distinction is not cosmetic: `quota` and `unavailable` are the provider's
+ * fault and must show the fallback message, while `bad_request` means we sent
+ * something wrong and deserves a log rather than a soothing sentence.
+ */
+type ProviderErrorKind = 'quota' | 'timeout' | 'unavailable' | 'bad_request'
+
+class ProviderError extends Error {
+  readonly kind: ProviderErrorKind
+
+  constructor(kind: ProviderErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'ProviderError'
+    this.kind = kind
+  }
+}
+
+interface ChatProvider {
+  /** Identifier used in logs and in the settings global. */
+  readonly id: string
+  /**
+   * Streams the answer as plain text chunks.
+   *
+   * Text rather than provider-specific events: the caller must never have to
+   * know how a vendor frames its payloads.
+   */
+  streamCompletion(request: CompletionRequest): AsyncIterable<string>
+}
+
+export { ProviderError }
+export type { ChatMessage, ChatProvider, CompletionRequest, ProviderErrorKind }

--- a/apps/frontend/src/lib/assistant-context.test.ts
+++ b/apps/frontend/src/lib/assistant-context.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The context is the assistant's entire knowledge of Adem: what lands in this
+ * string is what the model can say, and what is left out is what it cannot
+ * invent. These tests hold the two ends of that — the availability block keeping
+ * its authority, and the contact email staying out.
+ *
+ * The readers are mocked at the module boundary rather than through a database:
+ * what is under test is the assembly, not Payload.
+ */
+
+const identity = {
+  displayName: 'Adem',
+  role: 'Développeur web',
+  location: 'Lyon',
+  email: 'adem@example.com',
+  githubUrl: 'https://github.com/AdamDjo',
+  linkedinUrl: null,
+  legal: { publisher: 'Adem B.', hostName: null, hostAddress: null, dataPolicy: null },
+}
+
+const profile = {
+  headline: 'Interfaces rapides et accessibles',
+  bio: 'Je conçois des applications web.',
+  yearsOfExperience: 4,
+  skillGroups: [{ label: 'Frontend', items: ['React', 'Next.js'] }],
+  principles: [{ statement: 'Mesurer avant d’optimiser', detail: null }],
+}
+
+const state = {
+  availability: { available: true, label: 'Disponible pour des opportunités', detail: null } as {
+    available: boolean
+    label: string
+    detail: string | null
+  },
+  experiences: [
+    {
+      id: '1',
+      company: 'Acme',
+      role: 'Développeur',
+      location: null,
+      period: 'janvier 2024 — aujourd’hui',
+      project: null,
+      context: null,
+      achievements: [],
+      technologies: ['TypeScript'],
+    },
+  ],
+  projects: [
+    {
+      id: '1',
+      title: 'Portfolio',
+      description: 'Un portfolio piloté par un CMS.',
+      url: 'https://example.com',
+      repositoryUrl: null,
+      previewImageUrl: null,
+      coverUrl: null,
+      technologies: ['Next.js'],
+      featured: true,
+    },
+  ],
+  bookmarks: [{ title: 'React 19', tags: ['react'] }],
+  knowledge: [{ question: 'Comment travailles-tu ?', answer: 'Par itérations courtes.' }],
+}
+
+vi.mock('@/lib/site-content', () => ({
+  getIdentity: () => Promise.resolve(identity),
+  getAvailability: () => Promise.resolve(state.availability),
+  getProfile: () => Promise.resolve(profile),
+  listExperiences: () => Promise.resolve(state.experiences),
+  listProjects: () => Promise.resolve(state.projects),
+}))
+
+vi.mock('@/lib/bookmarks', () => ({
+  listPublicBookmarks: () => Promise.resolve(state.bookmarks),
+}))
+
+// The cache is a pass-through here: `unstable_cache` needs a Next request scope,
+// and what matters to these tests is the value, not where it was memoised.
+vi.mock('@/lib/content-cache', () => ({
+  CONTENT_TAGS: { aiKnowledge: 'content:ai-knowledge', assistant: 'content:assistant' },
+  cachedRead: <T>(_tag: string, _key: string, read: () => Promise<T>) => read,
+}))
+
+const findMock = vi.fn()
+vi.mock('payload', () => ({
+  getPayload: () =>
+    Promise.resolve({
+      find: findMock,
+      findGlobal: () =>
+        Promise.resolve({
+          enabled: true,
+          systemPrompt: 'prompt',
+          model: 'openai/gpt-oss-20b',
+          unavailableMessage: 'indisponible',
+        }),
+    }),
+}))
+vi.mock('@payload-config', () => ({ default: {} }))
+
+const { buildContext } = await import('./assistant-context')
+
+beforeEach(() => {
+  state.availability = {
+    available: true,
+    label: 'Disponible pour des opportunités',
+    detail: null,
+  }
+  findMock.mockReset()
+  findMock.mockResolvedValue({
+    docs: state.knowledge.map((entry) => ({ ...entry, category: 'methode' })),
+  })
+})
+
+describe('buildContext — disponibilité', () => {
+  it('place la disponibilité en tête, avant toute autre section', async () => {
+    const context = await buildContext()
+    expect(context.indexOf('## Disponibilité')).toBe(0)
+    expect(context.indexOf('## Disponibilité')).toBeLessThan(context.indexOf('## Parcours'))
+  })
+
+  it('déclare la section comme faisant autorité', async () => {
+    // Without this line the model happily infers availability from an older
+    // experience entry further down.
+    const context = await buildContext()
+    expect(context).toContain('Cette section fait autorité')
+  })
+
+  it('reprend le statut indisponible et sa précision', async () => {
+    state.availability = {
+      available: false,
+      label: 'En mission jusqu’en mars',
+      detail: 'Ouvert aux discussions pour la suite.',
+    }
+
+    const context = await buildContext()
+    expect(context).toContain('Statut : indisponible')
+    expect(context).toContain('En mission jusqu’en mars')
+    expect(context).toContain('Ouvert aux discussions pour la suite.')
+  })
+})
+
+describe('buildContext — confidentialité', () => {
+  it('n’expose jamais l’adresse e-mail de contact', async () => {
+    // Deliberate: the assistant invites contact, it does not hand out the address.
+    const context = await buildContext()
+    expect(context).not.toContain(identity.email)
+  })
+
+  it('ne demande à Payload que les connaissances publiées', async () => {
+    await buildContext()
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'ai-knowledge',
+        where: { published: { equals: true } },
+      })
+    )
+  })
+
+  it('n’inclut pas une réponse non publiée que Payload aurait laissé passer', async () => {
+    findMock.mockResolvedValue({
+      docs: [{ question: 'Brouillon', answer: 'Réponse interne', category: 'autre' }],
+    })
+
+    // The query filters, but the assertion is on the output: this is the property
+    // that actually matters if the query is ever loosened.
+    const published = await buildContext()
+    expect(published).toContain('Réponse interne')
+
+    findMock.mockResolvedValue({ docs: [] })
+    const context = await buildContext()
+    expect(context).not.toContain('Réponse interne')
+  })
+})
+
+describe('buildContext — assemblage', () => {
+  it('rend les sections attendues', async () => {
+    const context = await buildContext()
+    for (const heading of [
+      '## Identité',
+      '## Profil',
+      '## Compétences',
+      '## Parcours',
+      '## Projets',
+      '## Veille récente',
+      '## Réponses validées',
+    ]) {
+      expect(context).toContain(heading)
+    }
+  })
+
+  it('omet une section vide au lieu d’écrire un titre sans contenu', async () => {
+    state.projects = []
+    state.bookmarks = []
+
+    const context = await buildContext()
+    expect(context).not.toContain('## Projets')
+    expect(context).not.toContain('## Veille récente')
+
+    state.projects = [
+      {
+        id: '1',
+        title: 'Portfolio',
+        description: 'Un portfolio piloté par un CMS.',
+        url: 'https://example.com',
+        repositoryUrl: null,
+        previewImageUrl: null,
+        coverUrl: null,
+        technologies: ['Next.js'],
+        featured: true,
+      },
+    ]
+    state.bookmarks = [{ title: 'React 19', tags: ['react'] }]
+  })
+
+  it('limite la veille à 40 entrées', async () => {
+    state.bookmarks = Array.from({ length: 60 }, (_, index) => ({
+      title: `Article ${index}`,
+      tags: [],
+    }))
+
+    const context = await buildContext()
+    expect(context).toContain('Article 39')
+    expect(context).not.toContain('Article 40')
+
+    state.bookmarks = [{ title: 'React 19', tags: ['react'] }]
+  })
+})

--- a/apps/frontend/src/lib/assistant-context.ts
+++ b/apps/frontend/src/lib/assistant-context.ts
@@ -1,0 +1,222 @@
+import { getPayload } from 'payload'
+
+import { listPublicBookmarks } from '@/lib/bookmarks'
+import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
+import {
+  getAvailability,
+  getIdentity,
+  getProfile,
+  listExperiences,
+  listProjects,
+} from '@/lib/site-content'
+import config from '@payload-config'
+
+import type { AiKnowledge, AssistantSetting } from '@/payload-types'
+
+/**
+ * Builds the context handed to the model.
+ *
+ * The whole context is assembled from the same cached readers the pages use, so
+ * the assistant can never contradict what a visitor sees — availability above
+ * all, which #7 made a single source of truth.
+ *
+ * The guiding rule is that everything reaching this string is already public,
+ * with one deliberate exception: `ai-knowledge`, private in the API and included
+ * here because generated prose is precisely what it exists for. Anything else
+ * that is not on a page has no business being here.
+ */
+
+interface AssistantConfig {
+  enabled: boolean
+  systemPrompt: string
+  model: string
+  unavailableMessage: string
+}
+
+interface KnowledgeEntry {
+  question: string
+  answer: string
+  category: string
+}
+
+const toConfig = (doc: AssistantSetting): AssistantConfig => ({
+  enabled: Boolean(doc.enabled),
+  systemPrompt: doc.systemPrompt,
+  model: doc.model,
+  unavailableMessage: doc.unavailableMessage,
+})
+
+/**
+ * Reads the curated answers.
+ *
+ * `overrideAccess: true` is required and safe: the collection denies public
+ * reads, and this runs on the server with no visitor identity attached. Access
+ * control protects the API surface; here the entries never leave as data.
+ *
+ * `published` is enforced in the query rather than in a filter afterwards, so an
+ * unpublished entry is never even loaded into memory.
+ */
+const readKnowledge = async (): Promise<KnowledgeEntry[]> => {
+  const payload = await getPayload({ config })
+  const result = await payload.find({
+    collection: 'ai-knowledge',
+    where: { published: { equals: true } },
+    sort: 'category',
+    limit: 200,
+    overrideAccess: true,
+  })
+
+  return result.docs.map((doc: AiKnowledge) => ({
+    question: doc.question,
+    answer: doc.answer,
+    category: doc.category ?? 'autre',
+  }))
+}
+
+const readAssistantConfig = async (): Promise<AssistantConfig> => {
+  const payload = await getPayload({ config })
+  const doc = await payload.findGlobal({ slug: 'assistant-settings', overrideAccess: true })
+  return toConfig(doc)
+}
+
+const getKnowledge = cachedRead(CONTENT_TAGS.aiKnowledge, 'ai-knowledge:published', readKnowledge)
+const getAssistantConfig = cachedRead(
+  CONTENT_TAGS.assistant,
+  'assistant:config',
+  readAssistantConfig
+)
+
+/** Renders a section only when it has content, so the model never reads empty headings. */
+const section = (title: string, body: string): string =>
+  body.trim() ? `## ${title}\n${body}\n` : ''
+
+const list = (items: string[]): string => items.map((item) => `- ${item}`).join('\n')
+
+/**
+ * Assembles the context document.
+ *
+ * Markdown because it is what these models are trained on, and because the
+ * headings give the model something to cite implicitly when it answers.
+ */
+const buildContext = async (): Promise<string> => {
+  const [identity, availability, profile, experiences, projects, bookmarks, knowledge] =
+    await Promise.all([
+      getIdentity(),
+      getAvailability(),
+      getProfile(),
+      listExperiences(),
+      listProjects(),
+      listPublicBookmarks(),
+      getKnowledge(),
+    ])
+
+  // Availability comes first and is stated as authoritative: it is the one fact
+  // the model must never paraphrase from older content further down.
+  const availabilityBlock = [
+    `Statut : ${availability.available ? 'disponible' : 'indisponible'}`,
+    `Formulation affichée sur le site : « ${availability.label} »`,
+    availability.detail ? `Précision : ${availability.detail}` : null,
+    'Cette section fait autorité sur toute question de disponibilité.',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const identityBlock = [
+    `Prénom : ${identity.displayName}`,
+    `Métier : ${identity.role}`,
+    identity.location ? `Localisation : ${identity.location}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const profileBlock = [
+    profile.headline,
+    '',
+    profile.bio,
+    profile.yearsOfExperience ? `\nAnnées d’expérience : ${profile.yearsOfExperience}` : '',
+  ].join('\n')
+
+  const skillsBlock = list(
+    profile.skillGroups.map((group) => `${group.label} : ${group.items.join(', ')}`)
+  )
+
+  const principlesBlock = list(
+    profile.principles.map((principle) =>
+      principle.detail ? `${principle.statement} — ${principle.detail}` : principle.statement
+    )
+  )
+
+  const experiencesBlock = experiences
+    .map((entry) => {
+      const lines = [
+        `### ${entry.role} — ${entry.company} (${entry.period})`,
+        entry.location ? `Lieu : ${entry.location}` : null,
+        entry.context,
+        entry.achievements.length ? list(entry.achievements) : null,
+        entry.technologies.length ? `Technologies : ${entry.technologies.join(', ')}` : null,
+      ]
+      return lines.filter(Boolean).join('\n')
+    })
+    .join('\n\n')
+
+  const projectsBlock = projects
+    .map((project) => {
+      const lines = [
+        `### ${project.title}`,
+        project.description,
+        project.technologies.length ? `Technologies : ${project.technologies.join(', ')}` : null,
+        `Lien : ${project.url}`,
+      ]
+      return lines.filter(Boolean).join('\n')
+    })
+    .join('\n\n')
+
+  // Titles and tags only: the veille is a reading list, and the model has no use
+  // for the descriptions beyond knowing what Adem follows.
+  const bookmarksBlock = list(
+    bookmarks
+      .slice(0, 40)
+      .map((entry) =>
+        entry.tags.length ? `${entry.title} (${entry.tags.join(', ')})` : entry.title
+      )
+  )
+
+  const knowledgeBlock = knowledge
+    .map((entry) => `### ${entry.question}\n${entry.answer}`)
+    .join('\n\n')
+
+  return [
+    section('Disponibilité', availabilityBlock),
+    section('Identité', identityBlock),
+    section('Profil', profileBlock),
+    section('Compétences', skillsBlock),
+    section('Principes de travail', principlesBlock),
+    section('Parcours', experiencesBlock),
+    section('Projets', projectsBlock),
+    section('Veille récente', bookmarksBlock),
+    section('Réponses validées', knowledgeBlock),
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+/**
+ * The contact email is deliberately absent from every block above.
+ *
+ * It sits in `SiteIdentity` next to the fields that are used, so leaving it out
+ * has to be a decision rather than an oversight: the site shows it behind its own
+ * page, and an assistant that recites it on request turns the portfolio into an
+ * address harvester. The model is told to invite contact, not to hand out the
+ * address.
+ */
+
+/**
+ * `buildContext` is intentionally not wrapped in a `cachedRead` of its own.
+ *
+ * It composes seven readers that are each already cached under their own tag, so
+ * the work per call is string assembly over warm data. A cache on top would need
+ * a tag purged by all seven collections at once; under any single tag — editing a
+ * project, say — it would keep serving a context the pages have already moved
+ * past, and the assistant would contradict the site.
+ */
+export { buildContext, getAssistantConfig, type AssistantConfig }

--- a/apps/frontend/src/lib/content-cache.ts
+++ b/apps/frontend/src/lib/content-cache.ts
@@ -29,6 +29,8 @@ const CONTENT_TAGS = {
   experiences: 'content:experiences',
   projects: 'content:projects',
   bookmarks: 'content:bookmarks',
+  aiKnowledge: 'content:ai-knowledge',
+  assistant: 'content:assistant',
 } as const
 
 type ContentTag = (typeof CONTENT_TAGS)[keyof typeof CONTENT_TAGS]
@@ -51,6 +53,10 @@ const PAGES_BY_TAG: Record<ContentTag, { path: string; type?: 'layout' | 'page' 
   [CONTENT_TAGS.experiences]: [{ path: '/a-propos' }],
   [CONTENT_TAGS.projects]: [{ path: '/' }, { path: '/projets' }],
   [CONTENT_TAGS.bookmarks]: [{ path: '/' }, { path: '/veille' }],
+  // The assistant answers from a route handler, so no page holds this content:
+  // purging the cache entry is enough, there is no HTML to replace.
+  [CONTENT_TAGS.aiKnowledge]: [],
+  [CONTENT_TAGS.assistant]: [],
 }
 
 /**

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -73,6 +73,7 @@ export interface Config {
     experiences: Experience
     tags: Tag
     bookmarks: Bookmark
+    'ai-knowledge': AiKnowledge
     'payload-kv': PayloadKv
     'payload-locked-documents': PayloadLockedDocument
     'payload-preferences': PayloadPreference
@@ -86,6 +87,7 @@ export interface Config {
     experiences: ExperiencesSelect<false> | ExperiencesSelect<true>
     tags: TagsSelect<false> | TagsSelect<true>
     bookmarks: BookmarksSelect<false> | BookmarksSelect<true>
+    'ai-knowledge': AiKnowledgeSelect<false> | AiKnowledgeSelect<true>
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>
     'payload-locked-documents':
       | PayloadLockedDocumentsSelect<false>
@@ -101,11 +103,13 @@ export interface Config {
     'site-identity': SiteIdentity
     availability: Availability
     profile: Profile
+    'assistant-settings': AssistantSetting
   }
   globalsSelect: {
     'site-identity': SiteIdentitySelect<false> | SiteIdentitySelect<true>
     availability: AvailabilitySelect<false> | AvailabilitySelect<true>
     profile: ProfileSelect<false> | ProfileSelect<true>
+    'assistant-settings': AssistantSettingsSelect<false> | AssistantSettingsSelect<true>
   }
   locale: null
   widgets: {
@@ -319,6 +323,33 @@ export interface Bookmark {
   createdAt: string
 }
 /**
+ * Réponses que l’assistant peut donner sur Adem. Ce contenu n’est jamais affiché sur le site et n’est pas exposé publiquement.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ai-knowledge".
+ */
+export interface AiKnowledge {
+  id: number
+  /**
+   * La question telle qu’un visiteur la poserait.
+   */
+  question: string
+  /**
+   * Ce que l’assistant doit répondre. Écrit à la troisième personne.
+   */
+  answer: string
+  /**
+   * Sert à regrouper les entrées dans le contexte envoyé au modèle.
+   */
+  category?: ('parcours' | 'competences' | 'methode' | 'collaboration' | 'autre') | null
+  /**
+   * Décochée, l’entrée reste ici sans jamais être transmise au modèle.
+   */
+  published?: boolean | null
+  updatedAt: string
+  createdAt: string
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -365,6 +396,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'bookmarks'
         value: number | Bookmark
+      } | null)
+    | ({
+        relationTo: 'ai-knowledge'
+        value: number | AiKnowledge
       } | null)
   globalSlug?: string | null
   user: {
@@ -516,6 +551,18 @@ export interface BookmarksSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ai-knowledge_select".
+ */
+export interface AiKnowledgeSelect<T extends boolean = true> {
+  question?: T
+  answer?: T
+  category?: T
+  published?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -657,6 +704,33 @@ export interface Profile {
   createdAt?: string | null
 }
 /**
+ * Comportement de l’assistant public. Les modifications s’appliquent sans redéploiement.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "assistant-settings".
+ */
+export interface AssistantSetting {
+  id: number
+  /**
+   * Décoché, le chat affiche un message d’indisponibilité au lieu de répondre.
+   */
+  enabled?: boolean | null
+  /**
+   * Instructions envoyées au modèle avant chaque conversation. Le contexte du site est ajouté automatiquement.
+   */
+  systemPrompt: string
+  /**
+   * Identifiant du modèle chez le fournisseur, par exemple openai/gpt-oss-20b.
+   */
+  model: string
+  /**
+   * Affiché en cas de panne du fournisseur, de quota épuisé ou d’assistant désactivé.
+   */
+  unavailableMessage: string
+  updatedAt?: string | null
+  createdAt?: string | null
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "site-identity_select".
  */
@@ -721,6 +795,19 @@ export interface ProfileSelect<T extends boolean = true> {
         detail?: T
         id?: T
       }
+  updatedAt?: T
+  createdAt?: T
+  globalType?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "assistant-settings_select".
+ */
+export interface AssistantSettingsSelect<T extends boolean = true> {
+  enabled?: T
+  systemPrompt?: T
+  model?: T
+  unavailableMessage?: T
   updatedAt?: T
   createdAt?: T
   globalType?: T

--- a/apps/frontend/src/styles/responsive.css
+++ b/apps/frontend/src/styles/responsive.css
@@ -47,7 +47,10 @@
     right: 0;
     left: 0;
     width: auto;
+    /* The ceiling follows .hero-visual: the card is anchored on its bottom edge,
+       so anything taller overflows the hero and covers the copy above it. */
     max-width: 520px;
+    max-height: 460px;
     margin-inline: auto;
   }
   .hero-location {
@@ -98,6 +101,7 @@
   }
   .chat-card {
     bottom: 0;
+    max-height: 430px;
   }
   .feature-heading p {
     letter-spacing: 0.18em;

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: { '@': resolve(__dirname, './src') },
+    // Mirrors the `paths` of tsconfig.json: `@payload-config` is resolved by the
+    // Next build, and Vitest has to be told about it separately or any module
+    // importing it fails to load — before `vi.mock` ever gets a chance to run.
+    alias: {
+      '@': resolve(__dirname, './src'),
+      '@payload-config': resolve(__dirname, './src/cms/payload.config.ts'),
+    },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@20.19.41)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^15


### PR DESCRIPTION
## Summary

The hero chat used to display a hardcoded answer from `_content.ts`. It now talks
to a real assistant that answers from the site's own content.

Context is injected directly into the prompt rather than retrieved from a vector
database: the corpus is a personal portfolio, small enough to fit in a context
window, so a vector store would add infrastructure without improving answers.

### What ships

- **`AIKnowledge` collection** — admin-only, for facts that should feed the
  assistant without being displayed on the site.
- **`AssistantSettings` global** — system prompt, model and an on/off switch.
  These are content: tuning the assistant's tone should not need a redeploy. The
  API key stays in the environment, never in the database.
- **Availability as the single source of truth** — quoted from its global and
  placed first in the context, so the model treats it as authoritative rather
  than guessing from prose.
- **Provider abstraction** — a `ChatProvider` interface; Groq with
  `openai/gpt-oss-20b` is the only implementation so far. `AI_PROVIDER` selects
  it, and an unknown name fails loudly instead of silently falling back.
- **Privacy at the source** — drafts and unpublished entries are filtered in the
  query, and the contact email is deliberately excluded from the context: the
  site has a contact form for that.
- **Graceful degradation** — timeouts plus an editable fallback message, so a
  provider outage, an exhausted quota or a disabled assistant produces a
  sentence rather than an error.
- **Streaming UI** — pending, typing and error states in the chat.

### Public vs private access

| Endpoint | Anonymous |
|---|---|
| `POST /api/chat` | 200 — public, no auth |
| `/api/ai-knowledge` | 403 |
| `/api/globals/assistant-settings` | 403 |
| `/api/globals/profile`, `/api/experiences` | 200 |

Private content is read server-side with `overrideAccess: true`, injected into
the prompt, and never leaves as data.

## Test plan

Automated:

- `pnpm lint` — clean across 4 packages
- `pnpm type-check` — clean
- `pnpm test` — **81 tests / 5 files**
  - `groq.test.ts` (14): SSE parsing including a frame split across two network
    packets, `[DONE]` and malformed JSON handling, HTTP status → error kind
    mapping, and a client abort that must *not* become a `ProviderError`
  - `index.test.ts` (6): provider resolution, missing/blank key, unknown name
  - `assistant-context.test.ts` (9): availability first and marked
    authoritative, email absent from the context, unpublished entries excluded,
    empty sections omitted, bookmarks capped
- `pnpm build` — succeeds; `/api/chat` is listed as its own dynamic route,
  confirming the static segment wins over Payload's `/api/[...slug]` catch-all

Manual, against the real Groq key:

- Streaming works end to end
- Context injection is real — answers cite CAST Software, Canal+, Orange,
  Atayen, Grimoire, Ethswap, Fitapp, all from Payload
- Asking for the contact email is refused, with a pointer to the contact form
- Availability is quoted verbatim from the badge and cited as authoritative
- Input validation returns 400 for an empty question, a 1200-character question,
  and a `role: "system"` entry smuggled into `history` (prompt-injection guard)
- A salary/SSN probe is refused

## Known limitation

`openai/gpt-oss-20b` does not reliably honour the "out of scope" instruction: it
still answers some off-topic general-knowledge questions (a recipe, a capital
city). Three prompt rewrites did not fix it — small models follow positive
instructions better than prohibitions. Accepted as-is for now: the case is
marginal on a portfolio, and the fix is a one-field model change in `/admin`
should it ever matter.

The "assistant disabled from Payload" branch is covered by unit tests rather
than end to end: flipping that switch needs an admin session. All three fallback
branches converge on the same `fallbackResponse`, and the sibling
`resolveProvider() === null` branch is unit tested.

## Note

`zod` was missing from the whole monorepo despite being listed as a universal
dependency in CLAUDE.md. Installed in the frontend as `zod@4.4.3`.

Closes #9
