### PR TITLE
fix(frontend): bound the hero chat card and scroll its transcript

### DIFF
--- a/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
+++ b/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
@@ -4,7 +4,14 @@ import { ArrowRight, Send, Sparkles } from 'lucide-react'
 import { AnimatePresence, m, useScroll, useTransform } from 'motion/react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useImperativeHandle, useRef, useState, type FormEvent, type RefObject } from 'react'
+import {
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type FormEvent,
+  type RefObject,
+} from 'react'
 
 import { HOME_CONTENT } from '@/app/(site)/(home)/_content'
 import { EASE_OUT_QUINT, Stagger, StaggerItem } from '@/components/motion/primitives'
@@ -15,6 +22,8 @@ import { AvailabilityBadge } from './availability-badge'
 import type { HomeAvailability } from './types'
 
 const { hero, chat } = HOME_CONTENT
+
+const FOLLOW_TAIL_THRESHOLD = 80
 
 export interface HeroChatHandle {
   /** Scrolls to the chat input and focuses it, prefilling it when given a question. */
@@ -32,12 +41,29 @@ interface HeroProps {
 export function Hero({ role, location, availability, chatRef, onStartChat }: HeroProps) {
   const heroRef = useRef<HTMLElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const threadRef = useRef<HTMLDivElement>(null)
   const [question, setQuestion] = useState('')
   const { turns, streaming, pending, error, ask } = useAssistant()
 
   // The scripted exchange is the empty state: it shows what the chat is for.
   // The moment a real question lands it steps aside for the conversation.
   const started = turns.length > 0
+
+  // The transcript is bounded and scrollable, so new tokens would otherwise
+  // stream in below the fold. Following the tail keeps the answer in view while
+  // it is written, which is the only moment the visitor cares about.
+  useEffect(() => {
+    const thread = threadRef.current
+    if (!thread) return
+
+    // Someone who scrolled up is reading an earlier turn; yanking them back to
+    // the bottom on every token would make that impossible.
+    const distanceFromBottom = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+    if (distanceFromBottom > FOLLOW_TAIL_THRESHOLD) return
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    thread.scrollTo({ top: thread.scrollHeight, behavior: reduceMotion ? 'auto' : 'smooth' })
+  }, [turns, streaming, pending])
 
   useImperativeHandle(chatRef, () => ({
     ask(prefill) {
@@ -192,7 +218,7 @@ export function Hero({ role, location, availability, chatRef, onStartChat }: Her
 
           {/* The live conversation. `aria-live` is polite so a screen reader
               announces the finished answer without interrupting on every token. */}
-          <div className="chat-thread" aria-live="polite" aria-busy={pending}>
+          <div className="chat-thread" ref={threadRef} aria-live="polite" aria-busy={pending}>
             {turns.map((turn, index) =>
               turn.role === 'user' ? (
                 <m.div

--- a/apps/frontend/src/app/(site)/(home)/_styles.css
+++ b/apps/frontend/src/app/(site)/(home)/_styles.css
@@ -158,8 +158,15 @@
   right: -28px;
   bottom: 4px;
   z-index: 4;
+  display: flex;
   width: min(100%, 550px);
   min-height: 260px;
+  /* The card is anchored on `bottom` and out of flow, so it grows upwards as
+     turns are appended and nothing can push the page down to make room. A fixed
+     ceiling keeps it inside its container; the transcript takes whatever height
+     is left once the header and the form have taken theirs. */
+  max-height: 520px;
+  flex-direction: column;
   padding: 24px;
   border: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
   border-radius: 20px;
@@ -171,6 +178,8 @@
 }
 .chat-header {
   display: flex;
+  /* Header and form are fixed furniture: only the transcript may be compressed. */
+  flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
@@ -206,6 +215,9 @@
 }
 .message {
   width: fit-content;
+  /* The card is a flex column now; a message must keep its natural height
+     rather than be compressed to make room. */
+  flex: 0 0 auto;
   max-width: 86%;
   border-radius: 12px;
   padding: 12px 15px;
@@ -219,6 +231,7 @@
 }
 .message-row {
   display: flex;
+  flex: 0 0 auto;
   align-items: flex-start;
   gap: 13px;
   margin-top: 16px;
@@ -242,13 +255,26 @@
 /* The live conversation, below the scripted example. */
 .chat-thread {
   display: flex;
+  /* The one scroll container of the card. `min-height: 0` is what actually
+     enables it: a flex child defaults to `min-height: auto`, which refuses to
+     shrink below its content and would push the overflow back out of the card. */
+  min-height: 0;
+  flex: 1 1 auto;
   flex-direction: column;
+  /* `auto` rather than `scroll`: the short conversations that fit show no track,
+     and the scripted empty state keeps its original look. */
+  overflow-y: auto;
+  /* Keeps a wheel gesture inside the transcript from continuing into the page
+     once the thread hits its end. */
+  overscroll-behavior: contain;
   /* An empty thread must not push the form down, so the gap only applies
      between children that actually exist. */
   gap: 16px;
 }
 .chat-thread:not(:empty) {
   margin-top: 16px;
+  /* Keeps the scrollbar off the text once the transcript overflows. */
+  padding-right: 4px;
 }
 .chat-thread .message-row {
   margin-top: 0;
@@ -300,6 +326,7 @@
   font-size: 12px;
 }
 .chat-form {
+  flex: 0 0 auto;
   display: flex;
   gap: 9px;
   margin-top: 20px;

--- a/apps/frontend/src/styles/responsive.css
+++ b/apps/frontend/src/styles/responsive.css
@@ -47,7 +47,10 @@
     right: 0;
     left: 0;
     width: auto;
+    /* The ceiling follows .hero-visual: the card is anchored on its bottom edge,
+       so anything taller overflows the hero and covers the copy above it. */
     max-width: 520px;
+    max-height: 460px;
     margin-inline: auto;
   }
   .hero-location {
@@ -98,6 +101,7 @@
   }
   .chat-card {
     bottom: 0;
+    max-height: 430px;
   }
   .feature-heading p {
     letter-spacing: 0.18em;


### PR DESCRIPTION
## Summary

The hero chat card is positioned absolutely and anchored on its bottom edge, so
it grew upwards as turns were appended — nothing in the flow could push the page
down to make room. A long conversation ran past the hero and under the site
header, and no part of the subtree could scroll, so earlier turns were
unreachable.

The card now has a fixed ceiling and is a flex column: the header and the form
keep their natural height while the transcript takes what is left and becomes
the single scroll container. `min-height: 0` is the load-bearing declaration —
a flex child defaults to `min-height: auto` and refuses to shrink below its
content, which would push the overflow straight back out of the card.

The ceiling is per-breakpoint because it has to fit inside `.hero-visual`, which
is shorter on small screens (590 / 540 / 490px). Without the tablet and mobile
values the card overflowed its container and covered the hero copy above it —
this was a real regression caught on a 375px viewport, where a 520px card sat in
a 490px container and hid the "Senior Frontend Developer · Île-de-France, Paris"
line.

The transcript also follows the tail while an answer streams in, since it is
bounded now and new tokens would otherwise arrive below the fold. A visitor who
scrolled up to read an earlier turn is left alone (80px threshold), and the
smooth scroll is dropped under `prefers-reduced-motion`.

## Changes

- `_styles.css` — `.chat-card` becomes a flex column with `max-height: 520px`;
  `.chat-thread` becomes the scroll container (`flex: 1 1 auto`, `min-height: 0`,
  `overflow-y: auto`, `overscroll-behavior: contain`); header, form, messages and
  message rows are pinned with `flex: 0 0 auto`.
- `responsive.css` — `max-height: 460px` at ≤900px and `430px` at ≤640px, so the
  card stays inside the shorter `.hero-visual` on tablet and mobile.
- `hero.tsx` — a `useEffect` keeps the transcript pinned to the tail while an
  answer streams, unless the visitor has scrolled up past the threshold.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check --filter @portfolio/frontend`
- [x] 7-turn streamed conversation driven through the running dev server
- [x] Geometry measured at 1440px, 900px and 375px
- [x] `prefers-reduced-motion` behaviour verified

## Validation results

Measured against a real 7-turn conversation, page at scroll position 0:

| Width | Card height | `.hero-visual` | Overlaps header/copy | Input visible | Transcript scrollable |
| --- | --- | --- | --- | --- | --- |
| 1440px | 520px | 590px | no | yes | yes |
| 900px | 460px | 540px | no | yes | yes |
| 375px | 430px | 490px | no | yes | yes |

Scrolling the transcript: content 855px in a 262px window at 1440px, reaches the
last message and returns to the first one, which stays readable.

`prefers-reduced-motion` with the preference simulated: the branch resolves to
`behavior: 'auto'` and the jump to the bottom is instantaneous — `scrollTop`
lands on 593, the exact maximum, with no animation.

## Notes

Based on `feature/9-assistant-ia` rather than `develop`: the file this fixes does
not exist on `develop` until #38 is merged.

Closes #40
