### PR TITLE
chore(frontend): install Vercel Web Analytics

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -28,6 +28,7 @@
     "@payloadcms/db-postgres": "^3.88.0",
     "@payloadcms/next": "^3.88.0",
     "@payloadcms/richtext-lexical": "^3.88.0",
+    "@vercel/analytics": "^2.0.1",
     "graphql": "^16.14.2",
     "lucide-react": "^0.460.0",
     "motion": "^13.1.0",

--- a/apps/frontend/src/app/(site)/layout.tsx
+++ b/apps/frontend/src/app/(site)/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/next'
 import { Inter } from 'next/font/google'
 
 import { MotionProvider } from '@/components/motion/motion-provider'
@@ -57,6 +58,7 @@ export default function RootLayout({
             <SiteShell>{children}</SiteShell>
           </MotionProvider>
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@payloadcms/richtext-lexical':
         specifier: ^3.88.0
         version: 3.88.0(@faceless-ui/modal@3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@payloadcms/next@3.88.0(@types/react@19.2.15)(graphql@16.14.2)(monaco-editor@0.56.0)(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.14.2)(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(@types/react@19.2.15)(monaco-editor@0.56.0)(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.14.2)(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)(yjs@13.6.32)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)
       graphql:
         specifier: ^16.14.2
         version: 16.14.2
@@ -2331,6 +2334,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3299,6 +3331,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -7184,6 +7217,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.41)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
+      react: 19.2.8
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(sass@1.77.4))':
     dependencies:


### PR DESCRIPTION
## Summary

Installs Vercel Web Analytics: adds `@vercel/analytics` and mounts `<Analytics />` in the site layout so page views are collected on the deployed site.

This redoes, from `develop`, the change the Vercel bot proposed in #41. That branch was cut from `main`; since `main` and `develop` have diverged (their common ancestor is the initial commit), retargeting it to `develop` dragged the `Release/0.1.0` and `Release/0.2.0` merge commits along and reported `CONFLICTING` with a diff over 20,000 lines. Starting from `develop` reduces the change to what it actually is: 3 files, 41 insertions.

One difference from the bot's version: the import order. `import-x/order` sorts a bare package import before a framework subpath import, so `@vercel/analytics/next` goes above `next/font/google` — that ordering is what made the lint check fail on the original branch.

### Not included, and why

The empty white project cards reported alongside this work are **already fixed on `develop`**: `--orb-a` / `--orb-b` are declared in both themes and `.project-visual` carries `background: var(--accent-gradient)`. A fix written against the bot's branch (which predates that work) was therefore redundant and was dropped rather than carried over.

## Test plan

- [x] `pnpm install --frozen-lockfile` — lockfile up to date
- [x] `pnpm lint` — pass
- [x] `pnpm type-check` — pass
- [x] Analytics mounted: `va.vercel-scripts.com/v1/script.debug.js` loaded, `window.va` defined
- [x] Project cards verified on `/projets`, light and dark: gradient painted, orbs coloured, fallback labels readable
- [x] Diff contains no generated files (`next-env.d.ts`, `payload-types.ts` restored)

## Validation results

| Check | Result |
|---|---|
| `pnpm lint` | pass |
| `pnpm type-check` | pass |
| Analytics script loaded | yes (`window.va` defined) |
| Cards `/projets` light | `--orb-a: #4f46e5`, `--orb-b: #7c3aed`, labels readable |
| Cards `/projets` dark | `--orb-a: #4338ca`, `--orb-b: #6d28d9`, labels readable |
| Branch base | `develop` (`6e2de81`), no conflict |

Closes #43
