### PR TITLE
docs(devops): fix the release and sync skills

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -44,5 +44,67 @@ Execute in order:
    3. Publish the GitHub Release with auto-generated changelog
    4. Open a PR release/<version> → main
 
+   ⚠️  Merge that PR with "Create a merge commit" — never Squash.
+       See "How the release PR must be merged" below.
+
    After the merge into main, run: /sync
    ```
+
+## How the release PR must be merged
+
+**Merge the `release/*` → `main` pull request with "Create a merge commit". Never
+Squash, never Rebase.** Adem performs the merge himself; state the rule when
+handing the PR over.
+
+A squash replaces the branch with a brand-new single-parent commit, so nothing on
+`main` records that it came from `develop`. Git then has no common ancestor to
+work from and falls back to the first commit of the repository:
+
+```bash
+git merge-base origin/main origin/develop   # -> f9ad411, "Initial commit"
+```
+
+Every file touched on both branches is reported as an add/add conflict from
+there, even when the two sides are byte-identical — 27 files on the 0.5.0
+release. The damage compounds: each squashed release adds another orphan commit,
+so the next release conflicts harder than the last.
+
+A merge commit has two parents. It links `main` to `develop`, the merge base
+becomes the real one, and the following release compares only what actually
+changed.
+
+Squash stays the right choice for `feature/*` → `develop`: those branches are
+deleted right after, so no genealogy is lost, and `develop` stays readable.
+
+### Checking the genealogy is intact
+
+After a release is merged into `main`:
+
+```bash
+git fetch origin && git merge-base origin/main origin/develop
+```
+
+It must print the recent merge commit. If it prints the initial commit, the PR
+was squashed and the link is broken again.
+
+### Repairing a broken link
+
+The repair is a merge that changes no file — it only reconnects the two
+branches. Carry it in the next release PR: branch from `develop`, merge
+`origin/main` into it with `--no-ff` (resolve conflicts by keeping the `develop`
+side, which is already a superset), then merge that PR with a merge commit.
+
+Verify the resolution changed nothing before pushing:
+
+```bash
+git diff --stat origin/develop   # must be empty
+```
+
+### Repository settings this depends on
+
+`allow_merge_commit` must stay enabled, otherwise GitHub only offers Squash and
+the release PR cannot be merged correctly:
+
+```bash
+gh api repos/AdamDjo/PortfolioAI --jq '{merge_commit:.allow_merge_commit, squash:.allow_squash_merge}'
+```

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -17,26 +17,39 @@ Execute in order:
 
    - If develop is already up to date with main, print "✅ develop is already up to date with main" and stop
 
-2. **Show the commits that will be brought into develop**
-
-3. **Merge main into develop**
+2. **Verify the release PR was not squashed**
 
    ```bash
-   git checkout develop
-   git pull origin develop
+   git merge-base origin/main origin/develop
+   ```
+
+   If this prints the repository's first commit instead of the release merge,
+   `main` was squashed and its link to `develop` is broken. Say so — the sync
+   below will report phantom conflicts on files that are identical on both
+   sides. The repair procedure is in the `/release` skill.
+
+3. **Show the commits that will be brought into develop**
+
+4. **Merge main into develop on a branch**
+
+   `develop` is protected: never push to it directly. Create an issue first,
+   then a branch from `develop`, and open a pull request.
+
+   ```bash
+   git checkout develop && git pull origin develop
+   git checkout -b chore/<issue>-sync-develop-with-main
    git merge origin/main --no-edit
+   git push -u origin chore/<issue>-sync-develop-with-main
    ```
 
-4. **Push develop**
+5. **Open the PR toward `develop`** with the usual checklist (Closes #<issue>,
+   assignee, labels, milestone, project). Adem merges it himself.
 
-   ```bash
-   git push origin develop
-   ```
-
-5. **Confirm:**
+6. **Confirm:**
 
    ```
-   ✅ develop is now up to date with main
+   ✅ Sync PR opened: <url>
 
+   Merge it to bring main back into develop.
    Ready to start a new feature: /feature <name>
    ```


### PR DESCRIPTION
Closes #47

Two fixes in the release workflow skills, both found while investigating the
phantom release conflicts tracked in #46.

## `/release` — document how the PR must be merged

The skill handed over a `release/*` → `main` pull request without saying how to
merge it. A squash replaces the branch with a single-parent commit, so nothing on
`main` records that it came from `develop`:

```
$ git log origin/main --format='%h  parents:[%p]  %s'
e8004c8  parents:[9a98ed4]  release: v0.5.0 (#45)
9a98ed4  parents:[22348dc]  Release/0.2.0 (#34)
22348dc  parents:[f9ad411]  Release/0.1.0 (#19)
```

Git then has no common ancestor and falls back to the first commit of the repo,
reporting every file touched on both sides as an add/add conflict even when the
content is identical — 27 files on 0.5.0.

Added a "How the release PR must be merged" section covering the rule itself, the
proof of why a squash breaks the genealogy, the post-merge verification, the
repair procedure, and the `allow_merge_commit` setting it depends on. It sits
right after the hand-over step, where it is read at the moment it matters, and
step 5 now carries a one-line warning pointing to it.

## `/sync` — stop pushing to `develop`

The skill instructed a direct push to a protected, PR-only branch:

```bash
git merge origin/main --no-edit
git push origin develop
```

It now goes through an issue, a branch and a pull request, like every other
change. A new first step checks `git merge-base origin/main origin/develop` so a
squashed release is reported up front rather than surfacing as phantom conflicts
halfway through the merge.

## Test plan

Docs only — no application code, no build output, nothing importable is touched.

- [x] `git diff --stat` limited to the two `SKILL.md` files (85 insertions, 10 deletions)
- [x] prettier ran clean on both files via lint-staged on commit
- [x] Every command quoted in the docs was run against this repository first; the
      outputs shown are the real ones
- [x] `git merge-base origin/main origin/develop` → `f9ad411` (Initial commit),
      confirming the broken link the docs describe is still present and will be
      repaired by the 0.6.0 release as decided in #46

## Note

`allow_merge_commit` has already been re-enabled on the repository, so the merge
mode this PR documents is actually available:

```
before: {"merge_commit":false,"rebase":false,"squash":true}
after:  {"merge_commit":true,"rebase":false,"squash":true}
```

This PR targets `develop` and can be squashed as usual — the merge-commit rule
applies only to `release/*` → `main`.
