### PR TITLE
fix(frontend): keep gradient tokens alive through the production build

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -115,6 +115,30 @@
   color-scheme: dark;
 }
 
+/*
+ * Keeps five tokens alive through the production build.
+ *
+ * `--accent-gradient`, `--accent-glow`, `--orb-a`, `--orb-b` and `--danger` are
+ * the only tokens referenced exclusively from route-level `_styles.css` files.
+ * The production CSS minifier does not see those usages and strips the
+ * declarations from both `:root` blocks as dead code, while leaving the
+ * `var()` references in place — an unresolved `var()` inside a `background`
+ * shorthand computes to `none`, which turned every gradient on the deployed
+ * site into a blank fill (see #54).
+ *
+ * Referencing them here, in the file that declares them, marks them as used.
+ * The rule matches nothing: `:root` is never a descendant of itself, so this
+ * paints no pixel and only exists to hold the reference.
+ */
+:root :root {
+  background-image: var(--accent-gradient);
+  box-shadow:
+    0 0 var(--accent-glow),
+    0 0 var(--orb-a),
+    0 0 var(--orb-b),
+    0 0 var(--danger);
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary

Restores every gradient on the deployed site. Project cards were rendering as
blank white frames, primary buttons and the assistant send button had lost their
fill, and the unavailability badge had lost its colour.

The cause was not in the components. The production CSS bundle kept the
consumers of five design tokens but dropped their declarations:

```css
.project-visual{background:var(--accent-gradient); ...}  /* present */
:root{ ... }                                             /* declaration missing */
:root[data-theme=dark]{ ... }                            /* declaration missing */
```

An unresolved `var()` inside a `background` shorthand computes to `none`, which
is the blank frame.

`--accent-gradient`, `--accent-glow`, `--orb-a`, `--orb-b` and `--danger` are
exactly the tokens referenced **only** from route-level `_styles.css` files. The
production minifier does not see those usages and removes the declarations as
dead code. Tokens referenced from `globals.css` itself survive, which is why
`--accent-solid` (used by `::selection`) was never affected.

This PR references the five tokens from the file that declares them, so they are
marked as used. The rule matches nothing — `html` is never a descendant of
itself — so it paints no pixel and exists solely to hold the reference.

## Affected selectors

- `.project-visual` — home page and projects page
- `.button-primary` — every primary button on the site
- `.chat-form button` — assistant send button
- `.veille-tag-editor-trigger`
- `.availability-idle` — unavailability badge (`--danger`)

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm type-check` — passes
- [x] `prettier --check` on the changed file — passes
- [x] CSS compiles: `✓ Compiled successfully`
- [x] The anchor rule survives minification in the client chunk:
      `:root :root{background-image:var(--accent-gradient);box-shadow:0 0 var(--accent-glow), ...}`
- [x] Both `:root` blocks declare all five tokens after the build, light and dark
- [x] `document.querySelectorAll(':root :root').length === 0` — the selector
      matches no element, so the rule cannot paint anything

## Validation

Diagnosed against the live site rather than assumed. Before this change, on
https://portfolio-adem-frontenddev.vercel.app:

```js
getComputedStyle(document.documentElement).getPropertyValue('--accent-gradient')
// ""
getComputedStyle(document.querySelector('.project-visual')).backgroundImage
// "none"
document.querySelector('.project-visual').innerHTML
// "<span>0<!-- -->1<!-- --> · <!-- -->Grimoire</span>"
```

The markup was correct throughout — this was never a data or hydration problem.

Bundle comparison: the production bundle `1jgpcp1w54n0t.css` (42511 bytes)
declares none of the five tokens; a clean local `next build` declares all five in
both `:root` blocks.

**Note on verification limits:** the local build already kept these tokens before
this change, so the local build alone cannot prove the fix. The real proof is the
Vercel preview deployment for this PR — the five tokens must appear in its CSS
bundle. Worth checking the preview before merging.

The full local `next build` stops at the prerender step for lack of database
access (`max clients reached in session mode`), which is unrelated to CSS: the
stylesheets are emitted before that step and were inspected directly.

## Follow-up

Why the Vercel build applies this elimination when the local build does not —
likely a different resolved `lightningcss` version — is worth understanding, but
should not hold up restoring production. Not tracked as an issue yet; say the
word and I will open one.

Closes #54
