### PR TITLE
feat(frontend): wire the contact form to Lumail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,19 @@ GROQ_API_KEY=""
 # la variable existe pour en brancher un autre sans toucher au code appelant.
 # Laissée vide, la valeur par défaut « groq » s'applique.
 AI_PROVIDER=""
+
+# --- Email transactionnel (Lumail) ---
+# Jeton d'API Lumail, utilisé par le formulaire de contact.
+# Générez-le depuis votre organisation Lumail (Settings > API tokens).
+# Sans jeton, le formulaire refuse l'envoi au lieu d'échouer silencieusement.
+LUMAIL_API_TOKEN=""
+
+# Adresse d'expédition, sur un domaine vérifié dans Lumail (SPF/DKIM posés).
+# Exemple : contact@votre-domaine.fr
+LUMAIL_FROM_EMAIL=""
+
+# Nom affiché comme expéditeur.
+LUMAIL_FROM_NAME="Portfolio"
+
+# Adresse qui reçoit les messages du formulaire de contact.
+CONTACT_TO_EMAIL=""

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -20,3 +20,9 @@ GROQ_API_KEY=""
 
 # Fournisseur d'IA. Seul « groq » est implémenté ; vide = « groq ».
 AI_PROVIDER=""
+
+# Email transactionnel (Lumail) — voir le .env.example racine pour le détail.
+LUMAIL_API_TOKEN=""
+LUMAIL_FROM_EMAIL=""
+LUMAIL_FROM_NAME="Portfolio"
+CONTACT_TO_EMAIL=""

--- a/apps/frontend/src/app/(site)/contact/_actions.test.ts
+++ b/apps/frontend/src/app/(site)/contact/_actions.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The action is the only thing standing between a public form and a billed
+ * vendor, so what is pinned here is the behaviour that is invisible from the
+ * page: that a tripped honeypot looks exactly like a success, that a submission
+ * is never forwarded when the trap fires, and that an unconfigured environment
+ * is reported as its own state rather than as a failure.
+ *
+ * `next/headers` and the provider are mocked at the module boundary: what is
+ * under test is the decision flow, not Next's request plumbing nor Lumail.
+ */
+
+const send = vi.fn<(message: unknown) => Promise<void>>()
+const resolveEmailProvider = vi.fn<() => { id: string; send: typeof send } | null>()
+
+/**
+ * A distinct caller per test: the limiter is process-local and shared across
+ * cases, so a fixed address would make each test spend the next one's quota.
+ */
+let caller = 0
+vi.mock('next/headers', () => ({
+  headers: () => Promise.resolve(new Headers({ 'x-forwarded-for': `203.0.113.${caller}` })),
+}))
+
+/**
+ * Only the resolver is replaced; everything else is kept as the real module.
+ * `EmailError` in particular: the action narrows on `instanceof`, so a stubbed
+ * class would silently take the `unknown` branch and the error path under test
+ * would no longer be the production one.
+ *
+ * The real module is loaded inside the factory rather than imported at the top:
+ * `vi.mock` is hoisted above the imports, and a top-level binding into the very
+ * module being mocked is read before it is initialised.
+ */
+interface EmailModule {
+  resolveEmailProvider: unknown
+}
+
+vi.mock('@/lib/email', async () => {
+  const actual = await vi.importActual<EmailModule>('@/lib/email')
+  return { ...actual, resolveEmailProvider: () => resolveEmailProvider() }
+})
+
+const { submitContactForm } = await import('./_actions')
+
+const formData = (fields: Record<string, string>): FormData => {
+  const data = new FormData()
+  for (const [key, value] of Object.entries(fields)) data.append(key, value)
+  return data
+}
+
+const VALID = {
+  name: 'Camille',
+  email: 'camille@example.com',
+  subject: 'Une mission',
+  message: 'Bonjour, deux mots sur le projet.',
+}
+
+const submit = (fields: Record<string, string>) =>
+  submitContactForm({ status: 'idle' }, formData(fields))
+
+beforeEach(() => {
+  caller += 1
+  send.mockReset().mockResolvedValue(undefined)
+  resolveEmailProvider.mockReset().mockReturnValue({ id: 'lumail', send })
+})
+
+describe('submitContactForm', () => {
+  it('envoie le message quand tout est valide', async () => {
+    const state = await submit(VALID)
+
+    expect(state.status).toBe('sent')
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('annonce un succès sans rien envoyer quand le piège est rempli', async () => {
+    // A bot told it was caught is a bot whose next attempt works.
+    const state = await submit({ ...VALID, website: 'http://spam.example' })
+
+    expect(state.status).toBe('sent')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('ignore un piège rempli d’espaces, qui vient d’un autofill', async () => {
+    const state = await submit({ ...VALID, website: '   ' })
+
+    expect(state.status).toBe('sent')
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('signale l’absence de configuration comme un état, pas comme une panne', async () => {
+    resolveEmailProvider.mockReturnValue(null)
+
+    const state = await submit(VALID)
+
+    expect(state.status).toBe('unconfigured')
+  })
+
+  it('refuse une adresse invalide sans appeler le fournisseur', async () => {
+    const state = await submit({ ...VALID, email: 'pas-une-adresse' })
+
+    expect(state.status).toBe('error')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('refuse un message vide', async () => {
+    expect((await submit({ ...VALID, message: '   ' })).status).toBe('error')
+  })
+
+  it('rend une erreur lisible quand le fournisseur échoue', async () => {
+    send.mockRejectedValue(new Error('Lumail down'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const state = await submit(VALID)
+
+    expect(state.status).toBe('error')
+    // The vendor's own wording never reaches the visitor.
+    if (state.status === 'error') expect(state.message).not.toContain('Lumail')
+  })
+})

--- a/apps/frontend/src/app/(site)/contact/_actions.ts
+++ b/apps/frontend/src/app/(site)/contact/_actions.ts
@@ -1,0 +1,126 @@
+'use server'
+
+import { headers } from 'next/headers'
+import { z } from 'zod'
+
+import { EmailError, resolveEmailProvider } from '@/lib/email'
+import { buildContactMessage } from '@/lib/email/contact-message'
+import { allowSubmission } from '@/lib/email/rate-limit'
+
+/**
+ * Server action behind the contact form.
+ *
+ * It answers with a discriminated state rather than throwing: every outcome here
+ * is something the visitor should read in the form, including the case where no
+ * sender is configured at all.
+ */
+
+/**
+ * Bounds mirroring the column widths a human actually uses. They are validation,
+ * not politeness: the body is forwarded to a vendor that bills and rate-limits.
+ */
+const MAX_NAME_LENGTH = 100
+const MAX_SUBJECT_LENGTH = 150
+const MAX_MESSAGE_LENGTH = 5_000
+
+const submissionSchema = z.object({
+  name: z.string().trim().min(1, 'Nom requis').max(MAX_NAME_LENGTH),
+  /** Trimmed first: a pasted address often carries a trailing space. */
+  email: z.string().trim().pipe(z.email('Adresse invalide').max(MAX_NAME_LENGTH)),
+  subject: z.string().trim().min(1, 'Sujet requis').max(MAX_SUBJECT_LENGTH),
+  message: z.string().trim().min(1, 'Message requis').max(MAX_MESSAGE_LENGTH),
+  /**
+   * Honeypot. Hidden from people, so anything in it came from a bot filling
+   * every field it found.
+   *
+   * Deliberately not constrained to an empty string: rejecting it here would
+   * answer a filled trap with a validation error, which tells whoever wrote the
+   * bot exactly which field gave them away. It is parsed as free text and acted
+   * on below, once the submission is otherwise valid.
+   */
+  website: z.string().optional(),
+})
+
+/**
+ * What the form renders back.
+ *
+ * `unconfigured` is deliberately distinct from `error`: nothing failed, the site
+ * simply has no sending domain yet, and the form offers the mailto instead of
+ * apologising for a breakage that did not happen.
+ */
+type ContactState =
+  | { status: 'idle' }
+  | { status: 'sent' }
+  | { status: 'unconfigured' }
+  | { status: 'error'; message: string }
+
+/**
+ * Identifies the caller for throttling.
+ *
+ * `x-forwarded-for` is set by the platform proxy in front of the app. It is
+ * spoofable when the app is reached directly, which is why the honeypot carries
+ * the other half of the anti-spam and neither is trusted alone.
+ */
+const callerKey = async (): Promise<string> => {
+  const list = await headers()
+  const client = list.get('x-forwarded-for')?.split(',')[0]?.trim()
+
+  // An empty header is as useless as a missing one, so both share the bucket:
+  // unidentified callers throttle each other rather than bypassing the limit.
+  return client === undefined || client === '' ? 'unknown' : client
+}
+
+/** Visitor-facing wording. Vendor detail stays in the logs, never on screen. */
+const ERROR_MESSAGES = {
+  invalid: 'Vérifie les champs du formulaire.',
+  throttled: 'Tu viens déjà d’envoyer un message. Réessaie dans une minute.',
+  failed: 'L’envoi a échoué. Réessaie ou écris-moi directement.',
+} as const
+
+async function submitContactForm(
+  _previous: ContactState,
+  formData: FormData
+): Promise<ContactState> {
+  const parsed = submissionSchema.safeParse({
+    name: formData.get('name'),
+    email: formData.get('email'),
+    subject: formData.get('subject'),
+    message: formData.get('message'),
+    website: formData.get('website') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return { status: 'error', message: ERROR_MESSAGES.invalid }
+  }
+
+  const { website, ...submission } = parsed.data
+
+  /**
+   * A filled honeypot reports success without sending anything. Telling a bot it
+   * was detected only teaches whoever wrote it to fix the next attempt.
+   *
+   * Trimmed first, so a browser autofilling a space does not silently discard a
+   * real visitor's message.
+   */
+  if (website !== undefined && website.trim() !== '') return { status: 'sent' }
+
+  if (!allowSubmission(await callerKey())) {
+    return { status: 'error', message: ERROR_MESSAGES.throttled }
+  }
+
+  const provider = resolveEmailProvider()
+  if (!provider) return { status: 'unconfigured' }
+
+  try {
+    await provider.send(buildContactMessage(submission))
+  } catch (error) {
+    const kind = error instanceof EmailError ? error.kind : 'unknown'
+    console.error(`[contact] ${provider.id} ${kind}:`, error)
+    return { status: 'error', message: ERROR_MESSAGES.failed }
+  }
+
+  return { status: 'sent' }
+}
+
+export { submitContactForm }
+export type { ContactState }

--- a/apps/frontend/src/app/(site)/contact/_components/contact-form.tsx
+++ b/apps/frontend/src/app/(site)/contact/_components/contact-form.tsx
@@ -2,67 +2,102 @@
 
 import { Send } from 'lucide-react'
 import { AnimatePresence, m } from 'motion/react'
-import { useState, type FormEvent } from 'react'
+import { useActionState } from 'react'
 
 import { EASE_OUT_QUINT } from '@/components/motion/primitives'
 
+import { submitContactForm } from '../_actions'
 import { CONTACT_CONTENT } from '../_content'
+
+import type { ContactState } from '../_actions'
 
 /**
  * Contact form.
  *
- * No sending service is wired up yet: submitting sends nothing and the message
- * shown says so, rather than letting the visitor believe a message went out.
+ * Submission goes through a server action, so the message is sent even before
+ * this component hydrates. When no sender is configured the action says so and
+ * the form falls back to the mailto — the page never claims a message went out
+ * when none did.
  */
+
+const INITIAL_STATE: ContactState = { status: 'idle' }
+
+/** Shared entrance for the feedback line, whatever it ends up saying. */
+const FEEDBACK_MOTION = {
+  initial: { opacity: 0, y: 12, height: 0 },
+  animate: { opacity: 1, y: 0, height: 'auto' },
+  exit: { opacity: 0, height: 0 },
+  transition: { duration: 0.45, ease: EASE_OUT_QUINT },
+} as const
+
 export function ContactForm({ email }: { email: string }) {
-  const [sent, setSent] = useState(false)
+  const [state, action, pending] = useActionState(submitContactForm, INITIAL_STATE)
   const { form } = CONTACT_CONTENT
 
-  function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setSent(true)
-  }
-
   return (
-    <form className="contact-form" onSubmit={submit}>
+    <form className="contact-form" action={action}>
       <div className="field-row">
         <label htmlFor="contact-name">
           {form.nameLabel}
-          <input id="contact-name" name="name" required autoComplete="name" />
+          <input id="contact-name" name="name" required autoComplete="name" maxLength={100} />
         </label>
         <label htmlFor="contact-email">
           {form.emailLabel}
-          <input id="contact-email" name="email" type="email" required autoComplete="email" />
+          <input
+            id="contact-email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            maxLength={100}
+          />
         </label>
       </div>
       <label htmlFor="contact-subject">
         {form.subjectLabel}
-        <input id="contact-subject" name="subject" required />
+        <input id="contact-subject" name="subject" required maxLength={150} />
       </label>
       <label htmlFor="contact-message">
         {form.messageLabel}
-        <textarea id="contact-message" name="message" required rows={6} />
+        <textarea id="contact-message" name="message" required rows={6} maxLength={5000} />
       </label>
+      {/*
+        Honeypot: hidden from people and from assistive tech, left in the DOM for
+        bots that fill every field they find. `tabIndex={-1}` keeps it out of
+        keyboard navigation so nobody lands in it by accident.
+      */}
+      <input
+        className="honeypot"
+        type="text"
+        name="website"
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+      />
       <m.button
         className="button button-primary"
         type="submit"
-        whileHover={{ scale: 1.02 }}
-        whileTap={{ scale: 0.97 }}
+        disabled={pending}
+        whileHover={pending ? undefined : { scale: 1.02 }}
+        whileTap={pending ? undefined : { scale: 0.97 }}
         transition={{ type: 'spring', stiffness: 420, damping: 24 }}
       >
-        {form.submitLabel} <Send size={15} />
+        {pending ? form.pendingLabel : form.submitLabel} <Send size={15} />
       </m.button>
-      <AnimatePresence>
-        {sent ? (
-          <m.p
-            className="form-success"
-            role="status"
-            initial={{ opacity: 0, y: 12, height: 0 }}
-            animate={{ opacity: 1, y: 0, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.45, ease: EASE_OUT_QUINT }}
-          >
-            {form.successMessage} <a href={`mailto:${email}`}>{email}</a>.
+      <AnimatePresence mode="wait">
+        {state.status === 'sent' ? (
+          <m.p key="sent" className="form-success" role="status" {...FEEDBACK_MOTION}>
+            {form.successMessage}
+          </m.p>
+        ) : null}
+        {state.status === 'unconfigured' ? (
+          <m.p key="unconfigured" className="form-success" role="status" {...FEEDBACK_MOTION}>
+            {form.unconfiguredMessage} <a href={`mailto:${email}`}>{email}</a>.
+          </m.p>
+        ) : null}
+        {state.status === 'error' ? (
+          <m.p key="error" className="form-error" role="alert" {...FEEDBACK_MOTION}>
+            {state.message}
           </m.p>
         ) : null}
       </AnimatePresence>

--- a/apps/frontend/src/app/(site)/contact/_content.ts
+++ b/apps/frontend/src/app/(site)/contact/_content.ts
@@ -24,7 +24,9 @@ export const CONTACT_CONTENT = {
     subjectLabel: 'Sujet',
     messageLabel: 'Message',
     submitLabel: 'Envoyer le message',
-    successMessage:
-      'Le service d’envoi n’est pas encore branché. En attendant, écris-moi directement à',
+    pendingLabel: 'Envoi en cours…',
+    successMessage: 'Message envoyé. Je te réponds au plus vite.',
+    /** Shown when no sending domain is configured yet — nothing has failed. */
+    unconfiguredMessage: 'L’envoi n’est pas encore actif. En attendant, écris-moi directement à',
   },
 } as const

--- a/apps/frontend/src/lib/email/contact-message.test.ts
+++ b/apps/frontend/src/lib/email/contact-message.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildContactMessage } from './contact-message'
+
+const submission = {
+  name: 'Camille',
+  email: 'camille@example.com',
+  subject: 'Une mission',
+  message: 'Bonjour, deux mots sur le projet.',
+}
+
+/**
+ * The body is rendered as Markdown by the vendor, so visitor input reaches a
+ * renderer. These cases pin the two things that would otherwise go unnoticed:
+ * a reply that answers the visitor rather than a no-reply mailbox, and input
+ * that stays text instead of becoming formatting.
+ */
+describe('buildContactMessage', () => {
+  it('répond au visiteur, pas au domaine d’expédition', () => {
+    expect(buildContactMessage(submission).replyTo).toBe(submission.email)
+  })
+
+  it('préfixe le sujet tout en gardant celui du visiteur', () => {
+    const { subject } = buildContactMessage(submission)
+    expect(subject).toBe('[Portfolio] Une mission')
+  })
+
+  it('reporte l’expéditeur et son adresse dans le corps', () => {
+    const { text } = buildContactMessage(submission)
+    expect(text).toContain('Camille')
+    expect(text).toContain('camille@example.com')
+    expect(text).toContain(submission.message)
+  })
+
+  it('neutralise le Markdown en début de ligne au lieu de le rendre', () => {
+    const { text } = buildContactMessage({
+      ...submission,
+      message: '# Titre injecté\n- puce\n1. numéro\n> citation',
+    })
+
+    expect(text).toContain('\\# Titre injecté')
+    expect(text).toContain('\\- puce')
+    expect(text).toContain('\\1. numéro')
+    expect(text).toContain('\\> citation')
+  })
+
+  it('laisse intact un dièse en milieu de ligne, qui n’est pas un titre', () => {
+    const { text } = buildContactMessage({ ...submission, message: 'budget # 3' })
+    expect(text).toContain('budget # 3')
+  })
+
+  it('échappe aussi le nom et le sujet, pas seulement le message', () => {
+    const { text } = buildContactMessage({ ...submission, name: '# Faux titre' })
+    expect(text).toContain('\\# Faux titre')
+  })
+})

--- a/apps/frontend/src/lib/email/contact-message.ts
+++ b/apps/frontend/src/lib/email/contact-message.ts
@@ -1,0 +1,58 @@
+import type { EmailMessage } from './provider'
+
+/**
+ * Turns a form submission into the notification the site owner receives.
+ *
+ * Kept apart from the provider so the wording can change without touching the
+ * transport, and so the shape of the mail is readable in one place.
+ */
+
+interface ContactSubmission {
+  name: string
+  email: string
+  subject: string
+  message: string
+}
+
+/**
+ * Neutralises Markdown control characters at the start of a line.
+ *
+ * Lumail renders the body as Markdown, so a visitor writing `# free money` would
+ * otherwise land as a heading. This is presentation hygiene, not security: the
+ * recipient is the owner's own mailbox, and the value is never re-emitted as
+ * HTML by us.
+ */
+const escapeMarkdown = (value: string): string => value.replace(/^([#>\-*+=]|\d+\.)/gm, '\\$1')
+
+/**
+ * Subject line, prefixed so these land in one thread-able bucket.
+ *
+ * The visitor's own subject follows, because scanning an inbox by sender alone
+ * tells the owner nothing about what is being asked.
+ */
+const buildSubject = (subject: string): string => `[Portfolio] ${subject}`
+
+const buildContactMessage = ({
+  name,
+  email,
+  subject,
+  message,
+}: ContactSubmission): EmailMessage => ({
+  subject: buildSubject(subject),
+  text: [
+    `**De :** ${escapeMarkdown(name)} (${email})`,
+    `**Sujet :** ${escapeMarkdown(subject)}`,
+    '',
+    '---',
+    '',
+    escapeMarkdown(message),
+  ].join('\n'),
+  /**
+   * The visitor's address, so hitting reply answers them rather than the
+   * verified sending domain — which is a no-reply mailbox nobody reads.
+   */
+  replyTo: email,
+})
+
+export { buildContactMessage }
+export type { ContactSubmission }

--- a/apps/frontend/src/lib/email/index.test.ts
+++ b/apps/frontend/src/lib/email/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveEmailProvider } from './index'
+
+const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
+
+const COMPLETE = {
+  LUMAIL_API_TOKEN: 'lum_token',
+  LUMAIL_FROM_EMAIL: 'contact@domaine.fr',
+  CONTACT_TO_EMAIL: 'moi@example.com',
+}
+
+/**
+ * The resolver decides whether the contact form sends or falls back to a mailto.
+ * What matters is that a half-configured environment resolves to `null` rather
+ * than to a provider that would fail on every submission: the portfolio ships
+ * before its sending domain exists, and that is a state, not a bug.
+ */
+describe('resolveEmailProvider', () => {
+  it('retourne null quand rien n’est configuré', () => {
+    expect(resolveEmailProvider(env({}))).toBeNull()
+  })
+
+  it('retourne null tant qu’il manque une des trois variables requises', () => {
+    for (const missing of Object.keys(COMPLETE)) {
+      const partial = { ...COMPLETE, [missing]: '' }
+      expect(resolveEmailProvider(env(partial)), `sans ${missing}`).toBeNull()
+    }
+  })
+
+  it('traite une valeur blanche comme absente', () => {
+    expect(resolveEmailProvider(env({ ...COMPLETE, LUMAIL_API_TOKEN: '   ' }))).toBeNull()
+  })
+
+  it('construit le fournisseur quand les trois variables sont là', () => {
+    expect(resolveEmailProvider(env(COMPLETE))?.id).toBe('lumail')
+  })
+
+  it('n’exige pas le nom d’expéditeur, qui n’est que cosmétique', () => {
+    expect(resolveEmailProvider(env({ ...COMPLETE, LUMAIL_FROM_NAME: '' }))?.id).toBe('lumail')
+  })
+})

--- a/apps/frontend/src/lib/email/index.ts
+++ b/apps/frontend/src/lib/email/index.ts
@@ -1,0 +1,41 @@
+import { createLumailProvider } from './lumail'
+
+import type { EmailProvider } from './provider'
+
+/**
+ * Resolves the transactional sender from the environment.
+ *
+ * The vendor is not selectable at runtime, unlike the AI provider: there is one
+ * sender, and swapping it means swapping the adapter here. What the environment
+ * carries is the credentials and the addresses, which never belong in Payload.
+ */
+
+/**
+ * Builds the provider, or `null` when the environment does not configure one.
+ *
+ * `null` rather than a throw, mirroring `lib/ai`: a portfolio deployed before its
+ * sending domain exists is a deployment state, not a bug. The caller answers it
+ * with the mailto fallback, so the page keeps working while the DNS records are
+ * still propagating.
+ *
+ * All three values are required together — a token without a verified `from` is
+ * rejected by Lumail, and a `from` without a recipient has nowhere to land.
+ */
+const resolveEmailProvider = (env: NodeJS.ProcessEnv = process.env): EmailProvider | null => {
+  const apiToken = env.LUMAIL_API_TOKEN?.trim()
+  const fromEmail = env.LUMAIL_FROM_EMAIL?.trim()
+  const toEmail = env.CONTACT_TO_EMAIL?.trim()
+
+  if (!apiToken || !fromEmail || !toEmail) return null
+
+  // Cosmetic, so its absence is not a reason to refuse. A blank value is treated
+  // as unset rather than sent as an empty display name.
+  const trimmedName = env.LUMAIL_FROM_NAME?.trim()
+  const fromName = trimmedName === '' ? undefined : trimmedName
+
+  return createLumailProvider({ apiToken, fromEmail, fromName, toEmail })
+}
+
+export { resolveEmailProvider }
+export { EmailError } from './provider'
+export type { EmailErrorKind, EmailMessage, EmailProvider } from './provider'

--- a/apps/frontend/src/lib/email/lumail.test.ts
+++ b/apps/frontend/src/lib/email/lumail.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createLumailProvider } from './lumail'
+import { EmailError } from './provider'
+
+import type { EmailErrorKind } from './provider'
+
+const CONFIG = {
+  apiToken: 'lum_token',
+  fromEmail: 'contact@domaine.fr',
+  toEmail: 'moi@example.com',
+}
+
+const MESSAGE = { subject: 'Sujet', text: 'Corps', replyTo: 'visiteur@example.com' }
+
+/**
+ * Stubs `fetch` and hands back the spy. Typed with the arguments the adapter
+ * actually passes, so the recorded call can be read without casting through
+ * `unknown`.
+ */
+const stubFetch = (response: Response | Error) => {
+  const spy = vi.fn((_url: string, _init: RequestInit) =>
+    response instanceof Error ? Promise.reject(response) : Promise.resolve(response)
+  )
+  vi.stubGlobal('fetch', spy)
+  return spy
+}
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status })
+
+/** Shape of the payload the adapter posts, as far as these tests inspect it. */
+interface SentBody {
+  to: string
+  from: string
+  subject: string
+  content: string
+  replyTo?: string
+  tracking: { links: boolean; open: boolean }
+}
+
+/** Reads back the JSON body of the recorded call, typed rather than `any`. */
+const sentBody = (spy: ReturnType<typeof stubFetch>): SentBody => {
+  const [, init] = spy.mock.calls[0]
+  return JSON.parse(init.body as string) as SentBody
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * The adapter is the only place that knows Lumail's wire format. These cases pin
+ * the parts a caller depends on but cannot see: that failures arrive as a typed
+ * kind rather than a raw status, and that tracking stays off — link tracking
+ * would rewrite URLs inside a visitor's own message.
+ */
+describe('createLumailProvider', () => {
+  it('poste le message sur l’API avec le jeton en Bearer', async () => {
+    const fetchSpy = stubFetch(jsonResponse(200, { success: true }))
+
+    await createLumailProvider(CONFIG).send(MESSAGE)
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('https://lumail.io/api/v1/emails')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer lum_token')
+
+    expect(sentBody(fetchSpy)).toMatchObject({
+      to: CONFIG.toEmail,
+      from: CONFIG.fromEmail,
+      subject: 'Sujet',
+      content: 'Corps',
+      replyTo: 'visiteur@example.com',
+    })
+  })
+
+  it('désactive les deux traceurs, qui n’ont rien à faire dans une notification', async () => {
+    const fetchSpy = stubFetch(jsonResponse(200, { success: true }))
+
+    await createLumailProvider(CONFIG).send(MESSAGE)
+
+    const body = sentBody(fetchSpy)
+    expect(body.tracking).toEqual({ links: false, open: false })
+  })
+
+  it('affiche un nom d’expéditeur quand il est fourni', async () => {
+    const fetchSpy = stubFetch(jsonResponse(200, { success: true }))
+
+    await createLumailProvider({ ...CONFIG, fromName: 'Portfolio' }).send(MESSAGE)
+
+    const body = sentBody(fetchSpy)
+    expect(body.from).toBe('"Portfolio" <contact@domaine.fr>')
+  })
+
+  it('retombe sur l’adresse seule sans nom', async () => {
+    const fetchSpy = stubFetch(jsonResponse(200, { success: true }))
+
+    await createLumailProvider(CONFIG).send(MESSAGE)
+
+    const body = sentBody(fetchSpy)
+    expect(body.from).toBe('contact@domaine.fr')
+  })
+
+  it.each<[number, EmailErrorKind]>([
+    [400, 'bad_request'],
+    [401, 'unauthorized'],
+    [403, 'unauthorized'],
+    [404, 'bad_request'],
+    [429, 'rate_limited'],
+    [500, 'provider_error'],
+  ])('traduit le statut %i en %s', async (status, kind) => {
+    stubFetch(jsonResponse(status, { message: 'refusé' }))
+
+    await expect(createLumailProvider(CONFIG).send(MESSAGE)).rejects.toMatchObject({
+      name: 'EmailError',
+      kind,
+    })
+  })
+
+  it('signale une panne réseau plutôt que de la laisser fuiter', async () => {
+    stubFetch(new TypeError('fetch failed'))
+
+    await expect(createLumailProvider(CONFIG).send(MESSAGE)).rejects.toBeInstanceOf(EmailError)
+  })
+
+  it('survit à une réponse d’erreur qui n’est pas du JSON', async () => {
+    stubFetch(new Response('<html>502</html>', { status: 502 }))
+
+    await expect(createLumailProvider(CONFIG).send(MESSAGE)).rejects.toMatchObject({
+      kind: 'provider_error',
+    })
+  })
+})

--- a/apps/frontend/src/lib/email/lumail.ts
+++ b/apps/frontend/src/lib/email/lumail.ts
@@ -1,0 +1,102 @@
+import { EmailError } from './provider'
+
+import type { EmailMessage, EmailProvider } from './provider'
+
+/**
+ * Lumail transactional sender.
+ *
+ * Lumail is API-first: its own docs present the SMTP relay as the fallback for
+ * tools that speak nothing else. Both land in the same priority lane, so the API
+ * is the direct route and needs no extra dependency.
+ *
+ * The send is asynchronous — a 200 means Lumail queued the message, not that a
+ * mailbox received it. Nothing here should read as delivery confirmation.
+ */
+
+const ENDPOINT = 'https://lumail.io/api/v1/emails'
+
+interface LumailConfig {
+  apiToken: string
+  fromEmail: string
+  /** Display name shown as the sender. Optional: the address alone is valid. */
+  fromName?: string
+  /** Where contact notifications land. Unlike `fromEmail`, any domain works. */
+  toEmail: string
+}
+
+/**
+ * Builds the `from` value.
+ *
+ * RFC 5322 display-name form, so an inbox shows a name rather than a raw
+ * address. The name is quoted because a comma or a period in it would otherwise
+ * split the address, and unquoting is the vendor's job, not ours.
+ */
+const formatSender = (email: string, name?: string): string =>
+  name ? `"${name.replace(/"/g, '')}" <${email}>` : email
+
+/**
+ * Maps an HTTP status onto the kinds callers act on.
+ *
+ * 404 is folded into `bad_request`: Lumail returns it when the recipient cannot
+ * be resolved, which from here is a malformed address, not a server fault.
+ */
+const classify = (status: number, message: string): EmailError => {
+  if (status === 401 || status === 403) return new EmailError('unauthorized', message)
+  if (status === 429) return new EmailError('rate_limited', message)
+  if (status === 400 || status === 404) return new EmailError('bad_request', message)
+  return new EmailError('provider_error', message)
+}
+
+/** Pulls Lumail's error text out of a failed response without assuming its shape. */
+const readError = async (response: Response): Promise<string> => {
+  try {
+    const body: unknown = await response.json()
+    const message = (body as { message?: unknown })?.message
+    return typeof message === 'string' ? message : `Lumail HTTP ${response.status}`
+  } catch {
+    return `Lumail HTTP ${response.status}`
+  }
+}
+
+const createLumailProvider = ({
+  apiToken,
+  fromEmail,
+  fromName,
+  toEmail,
+}: LumailConfig): EmailProvider => ({
+  id: 'lumail',
+  send: async ({ subject, text, replyTo }: EmailMessage) => {
+    let response: Response
+    try {
+      response = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          to: toEmail,
+          from: formatSender(fromEmail, fromName),
+          subject,
+          content: text,
+          contentType: 'MARKDOWN',
+          replyTo,
+          /**
+           * Both trackers off. Link tracking rewrites every URL through a
+           * redirect, which mangles anything a visitor pasted into their
+           * message; open tracking embeds a pixel. Neither belongs in a
+           * notification addressed to the site owner.
+           */
+          tracking: { links: false, open: false },
+        }),
+      })
+    } catch (error) {
+      // Network-level failure: Lumail was never reached.
+      throw new EmailError('provider_error', error instanceof Error ? error.message : 'Réseau')
+    }
+
+    if (!response.ok) throw classify(response.status, await readError(response))
+  },
+})
+
+export { createLumailProvider }

--- a/apps/frontend/src/lib/email/provider.ts
+++ b/apps/frontend/src/lib/email/provider.ts
@@ -1,0 +1,53 @@
+/**
+ * Vendor-agnostic contract for sending one transactional email.
+ *
+ * The portfolio sends a handful of messages triggered one at a time — a contact
+ * form entry today, an account recovery mail tomorrow. Nothing here models
+ * campaigns, lists or templates: that is the vendor's own domain, and pulling it
+ * into this interface would tie the callers to whoever is behind it.
+ */
+
+/** What a caller hands over. `replyTo` is what makes an answer one click away. */
+interface EmailMessage {
+  subject: string
+  /** Plain text. Callers build it; no provider-specific templating is involved. */
+  text: string
+  /** Reply target, so answering the notification reaches the visitor directly. */
+  replyTo?: string
+}
+
+type EmailErrorKind =
+  /** The message itself is invalid — a rejected address, an empty body. */
+  | 'bad_request'
+  /** The token is missing, expired or lacks the scope to send. */
+  | 'unauthorized'
+  /** The vendor throttled us. */
+  | 'rate_limited'
+  /** The vendor failed or could not be reached. */
+  | 'provider_error'
+
+/**
+ * Failure that already carries its cause.
+ *
+ * The kind lets the caller decide what the visitor sees without parsing vendor
+ * payloads: a bad address is the visitor's problem to fix, everything else is
+ * ours to log and apologise for.
+ */
+class EmailError extends Error {
+  readonly kind: EmailErrorKind
+
+  constructor(kind: EmailErrorKind, message: string) {
+    super(message)
+    this.name = 'EmailError'
+    this.kind = kind
+  }
+}
+
+interface EmailProvider {
+  /** Vendor identifier, used in logs so a failure names who refused it. */
+  readonly id: string
+  send: (message: EmailMessage) => Promise<void>
+}
+
+export { EmailError }
+export type { EmailErrorKind, EmailMessage, EmailProvider }

--- a/apps/frontend/src/lib/email/rate-limit.test.ts
+++ b/apps/frontend/src/lib/email/rate-limit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { allowSubmission, MAX_PER_WINDOW, WINDOW_MS } from './rate-limit'
+
+/**
+ * The limiter is process-local and shared across tests, so every case uses its
+ * own key rather than resetting shared state — which is also how it behaves in
+ * production, one bucket per caller.
+ */
+describe('allowSubmission', () => {
+  it('laisse passer les premiers envois de la fenêtre', () => {
+    const now = Date.now()
+    for (let i = 0; i < MAX_PER_WINDOW; i += 1) {
+      expect(allowSubmission('caller-a', now + i)).toBe(true)
+    }
+  })
+
+  it('refuse une fois le quota de la fenêtre dépensé', () => {
+    const now = Date.now()
+    for (let i = 0; i < MAX_PER_WINDOW; i += 1) allowSubmission('caller-b', now + i)
+
+    expect(allowSubmission('caller-b', now + MAX_PER_WINDOW)).toBe(false)
+  })
+
+  it('rouvre après la fenêtre, pour ne pas bannir un visiteur légitime', () => {
+    const now = Date.now()
+    for (let i = 0; i < MAX_PER_WINDOW; i += 1) allowSubmission('caller-c', now + i)
+    expect(allowSubmission('caller-c', now + MAX_PER_WINDOW)).toBe(false)
+
+    expect(allowSubmission('caller-c', now + WINDOW_MS + 1)).toBe(true)
+  })
+
+  it('compte chaque appelant séparément', () => {
+    const now = Date.now()
+    for (let i = 0; i < MAX_PER_WINDOW; i += 1) allowSubmission('caller-d', now + i)
+    expect(allowSubmission('caller-d', now + MAX_PER_WINDOW)).toBe(false)
+
+    expect(allowSubmission('caller-e', now)).toBe(true)
+  })
+})

--- a/apps/frontend/src/lib/email/rate-limit.ts
+++ b/apps/frontend/src/lib/email/rate-limit.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory submission throttle.
+ *
+ * Deliberately not backed by Redis or Postgres: the portfolio runs a handful of
+ * instances at most, and a limiter that occasionally forgets a caller after a
+ * cold start is still the difference between a bot sending one message and a bot
+ * sending a thousand. Adding a datastore for this would cost more than it saves.
+ *
+ * The consequence is worth stating plainly — this bounds abuse, it does not
+ * block a determined attacker rotating IPs. Lumail's own quota is the real
+ * ceiling, and the honeypot catches the naive bots.
+ */
+
+/** One message per window is plenty: a human writing twice can wait a minute. */
+const WINDOW_MS = 60_000
+const MAX_PER_WINDOW = 2
+
+/**
+ * Timestamps of recent hits, keyed by caller.
+ *
+ * A plain `Map` grows unbounded, so expired keys are swept on write. The sweep
+ * is O(n) over the map, which stays small precisely because entries expire.
+ */
+const hits = new Map<string, number[]>()
+
+const sweep = (now: number): void => {
+  for (const [key, timestamps] of hits) {
+    const fresh = timestamps.filter((at) => now - at < WINDOW_MS)
+    if (fresh.length === 0) hits.delete(key)
+    else hits.set(key, fresh)
+  }
+}
+
+/**
+ * Records an attempt and reports whether it is allowed.
+ *
+ * Returns `false` once the caller has spent its window, so the caller decides
+ * what the visitor sees.
+ */
+const allowSubmission = (key: string, now: number = Date.now()): boolean => {
+  sweep(now)
+
+  const recent = (hits.get(key) ?? []).filter((at) => now - at < WINDOW_MS)
+  if (recent.length >= MAX_PER_WINDOW) return false
+
+  hits.set(key, [...recent, now])
+  return true
+}
+
+export { allowSubmission, MAX_PER_WINDOW, WINDOW_MS }

--- a/apps/frontend/src/styles/layout.css
+++ b/apps/frontend/src/styles/layout.css
@@ -219,6 +219,24 @@
   color: var(--success);
   font-size: 12px;
 }
+.form-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 12px;
+}
+/*
+  Honeypot: removed from the layout without `display: none`, which the more
+  careful bots detect and skip. Kept unreachable by pointer and keyboard so no
+  visitor can fill it by accident and have their message silently dropped.
+*/
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
 
 .search-bar {
   display: flex;


### PR DESCRIPTION
## Summary

Wires the contact form to a real transactional sender. It was inert markup — it collected a name, an address and a message, and dropped all three. Transport sits behind an `EmailProvider` contract with Lumail as the only adapter, and a missing sending domain is reported as its own state rather than as a failure, so the feature ships before the domain is bought.

## Related issue(s)

Closes #8

## Type of change

- [x] New feature (phase: 2)
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Chore / Tooling / Config
- [ ] Documentation only

## Domain

- **Phase**: phase: 2
- **Domain**: domain: frontend

## Technical checklist

- [x] Code follows `CLAUDE.md` conventions (naming, patterns)
- [x] Shared types in `packages/shared` (never duplicated)
- [x] `pnpm type-check` passes without error
- [x] `pnpm lint` passes without error
- [ ] No forgotten `console.log` — see note below, one `console.error` is deliberate
- [x] Manually tested (describe below)

## What changed

New `src/lib/email/`:

| File | Role |
|---|---|
| `provider.ts` | `EmailProvider` contract, `EmailError` with a typed `kind` |
| `lumail.ts` | Lumail adapter — Bearer auth, tracking off, HTTP statuses mapped to `kind` |
| `index.ts` | Environment resolver; returns `null` when unconfigured |
| `contact-message.ts` | Mail body — prefixed subject, `replyTo` on the visitor, Markdown escaped |
| `rate-limit.ts` | Two submissions per minute per caller, in memory |

Route: `_actions.ts` (server action — zod validation, honeypot, throttle) and `_components/contact-form.tsx` (`useActionState`, disabled while pending, three feedback branches). Contact form styles go in `src/styles/layout.css`, the shared sheet that already carries the form rules.

## Why Lumail and not Resend

The issue title says Resend. Lumail was chosen instead for a non-technical reason and the API surface is equivalent. Nothing in the design is Lumail-specific past `lumail.ts`: the contract, the message template and the action are all unaware of the vendor, so swapping it is one file.

## The `unconfigured` state

`resolveEmailProvider()` returns `null` when the environment configures no sender, mirroring `lib/ai`. The action surfaces that as `unconfigured`, distinct from `error`, and the form shows the mailto fallback rather than apologising for a breakage that did not happen.

This is load-bearing right now: **the sending domain does not exist yet.** Probing the live API with real credentials returns `HTTP 400 {"message":"Failed to queue email for sending"}` — Lumail refuses any `From` outside a verified domain, as Resend does. Once the domain is bought and its SPF/DKIM are in place, filling `LUMAIL_FROM_EMAIL` is the whole activation; no code changes.

## Manual test performed

Verified in the browser against the dev server, all three paths:

1. **Full env** — submit reaches the API, the rejection surfaces as a readable error, vendor wording never shown.
2. **`LUMAIL_FROM_EMAIL` blanked** — "L'envoi n'est pas encore actif…" plus the mailto. No error state, nothing logged as a failure.
3. **Honeypot filled** — success reported, `send` never called. Computed style confirmed off-screen (`position: absolute; left: -9999px`), `aria-hidden`, `tabIndex: -1`, not in viewport.

Automated: 115 tests pass across 10 files, 34 of them new here (resolver, message template, limiter, adapter, action).

## Notes for review

**A bug that only browser testing caught.** The honeypot was first constrained with `z.string().max(0)`. A filled trap therefore failed zod validation and rendered "Vérifie les champs du formulaire" — naming, to whoever wrote the bot, exactly which field gave them away. The schema now accepts free text and the trap is acted on after validation: success reported, nothing sent. Type-check and lint were both green on the broken version.

**The `console.error` is intentional.** `_actions.ts` logs the provider id and the error `kind` on a send failure. The visitor gets fixed wording; the diagnostic detail belongs in the logs, not on screen.

**Anti-spam is two weak guards, not one strong one.** `x-forwarded-for` is spoofable when the app is reached without a proxy in front, and the limiter is process-local — it bounds abuse, it does not stop IP rotation. The honeypot carries the other half. Neither is trusted alone.

**Tracking is off on every send.** Link tracking rewrites URLs, and these bodies are a visitor's own words.

**Left out of this branch deliberately:** `payload-types.ts`, `next-env.d.ts` and `pnpm-lock.yaml` are dirty in the working tree from generator/formatter runs (semicolons and quotes only, plus a `@types/node` 22→20 drift in the lock). None of it belongs to this feature, and committing 717 lines of punctuation noise would bury the review.

**Follow-ups, not blockers:** the Lumail token is full-access where the app only sends mail — worth narrowing. And I could not confirm whether Lumail exposes bounce webhooks; without them, a message rejected after the `200` is invisible to us.
