### PR TITLE
feat(frontend): add an AI tools page with copyable snippets

### DIFF
--- a/apps/frontend/src/app/(site)/outils-ia/_components/copy-button.tsx
+++ b/apps/frontend/src/app/(site)/outils-ia/_components/copy-button.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Check, Copy, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+import { OUTILS_IA_CONTENT } from '../_content'
+
+const COPY = OUTILS_IA_CONTENT.copy
+const FEEDBACK_MS = 1800
+
+type CopyState = 'idle' | 'done' | 'failed'
+
+const LABELS: Record<CopyState, string> = {
+  idle: COPY.idle,
+  done: COPY.done,
+  failed: COPY.failed,
+}
+
+/**
+ * Copies a snippet to the clipboard and reports the outcome on the button.
+ *
+ * `navigator.clipboard` is undefined outside a secure context, and even when
+ * present the write can be refused by the browser. Both paths land on the same
+ * `failed` state, which is why the page also shows the snippet as selectable
+ * text: the button is the shortcut, never the only way to get the value.
+ */
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [state, setState] = useState<CopyState>('idle')
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // A click landing right before unmount would otherwise set state on a gone
+  // component, and a second click must restart the delay rather than stack one.
+  useEffect(
+    () => () => {
+      if (timeout.current) clearTimeout(timeout.current)
+    },
+    []
+  )
+
+  const scheduleReset = () => {
+    if (timeout.current) clearTimeout(timeout.current)
+    timeout.current = setTimeout(() => setState('idle'), FEEDBACK_MS)
+  }
+
+  const handleCopy = async () => {
+    try {
+      if (!navigator.clipboard) throw new Error('clipboard unavailable')
+      await navigator.clipboard.writeText(value)
+      setState('done')
+    } catch {
+      setState('failed')
+    }
+    scheduleReset()
+  }
+
+  const Icon = state === 'done' ? Check : state === 'failed' ? X : Copy
+
+  return (
+    <button
+      aria-label={COPY.ariaLabel(label)}
+      className={state === 'idle' ? 'copy-button' : `copy-button is-${state}`}
+      onClick={handleCopy}
+      type="button"
+    >
+      <Icon aria-hidden="true" size={14} />
+      <span>{LABELS[state]}</span>
+      {/* Icon and colour carry the outcome visually; this announces it too. */}
+      <span aria-live="polite" className="sr-only">
+        {state === 'failed' ? COPY.unavailable : state === 'done' ? COPY.done : ''}
+      </span>
+    </button>
+  )
+}
+
+export { CopyButton }

--- a/apps/frontend/src/app/(site)/outils-ia/_components/tool-grid.tsx
+++ b/apps/frontend/src/app/(site)/outils-ia/_components/tool-grid.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { AnimatePresence, m } from 'motion/react'
+import { useMemo, useState } from 'react'
+
+import { EASE_OUT_QUINT } from '@/components/motion/primitives'
+
+import { OUTILS_IA_CONTENT } from '../_content'
+
+import { CopyButton } from './copy-button'
+
+import type { AIToolKind, AIToolView } from '@/lib/ai-tools'
+
+const { filter, kinds, card, grid } = OUTILS_IA_CONTENT
+const ALL = filter.allKinds
+
+/** Filters are ordered by kind, not by first appearance, so they never move. */
+const KIND_ORDER: AIToolKind[] = ['skill', 'plugin', 'mcp']
+
+/**
+ * Filterable grid of the AI tools.
+ *
+ * The data arrives already rendered by the server; this component only handles
+ * the kind filter and the copy affordance. It never writes: the page is
+ * read-only for everyone, additions go through `/admin`.
+ */
+function ToolGrid({ tools }: { tools: AIToolView[] }) {
+  const [activeKind, setActiveKind] = useState<AIToolKind | typeof ALL>(ALL)
+
+  // Only the kinds actually present: a filter that returns nothing is noise.
+  const availableKinds = useMemo(
+    () => KIND_ORDER.filter((kind) => tools.some((tool) => tool.kind === kind)),
+    [tools]
+  )
+
+  const visibleTools = useMemo(
+    () => (activeKind === ALL ? tools : tools.filter((tool) => tool.kind === activeKind)),
+    [tools, activeKind]
+  )
+
+  if (tools.length === 0) {
+    return <p className="tools-empty">{grid.emptyState}</p>
+  }
+
+  return (
+    <>
+      <div className="filter-row tools-filters" role="group" aria-label={filter.ariaLabel}>
+        <button
+          className={activeKind === ALL ? 'is-active' : undefined}
+          onClick={() => setActiveKind(ALL)}
+          type="button"
+          aria-pressed={activeKind === ALL}
+        >
+          {ALL}
+        </button>
+        {availableKinds.map((kind) => (
+          <button
+            className={kind === activeKind ? 'is-active' : undefined}
+            key={kind}
+            onClick={() => setActiveKind(kind)}
+            type="button"
+            aria-pressed={kind === activeKind}
+          >
+            {kinds[kind].label}
+          </button>
+        ))}
+      </div>
+      <div className="tools-grid">
+        <AnimatePresence mode="popLayout" initial={false}>
+          {visibleTools.map((tool) => (
+            <m.article
+              className="tool-card"
+              key={tool.id}
+              layout
+              initial={{ opacity: 0, scale: 0.94, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.94 }}
+              transition={{ duration: 0.35, ease: EASE_OUT_QUINT }}
+            >
+              <header className="tool-card-head">
+                <span className={`tool-kind tool-kind-${tool.kind}`}>{kinds[tool.kind].label}</span>
+                <h2>{tool.name}</h2>
+                {tool.description ? <p>{tool.description}</p> : null}
+              </header>
+
+              <div className="tool-snippet">
+                <div className="tool-snippet-head">
+                  <span>{kinds[tool.kind].snippetLabel}</span>
+                  <CopyButton label={tool.name} value={tool.snippet} />
+                </div>
+                {/* Selectable text, not just a copy target: the button is the
+                    shortcut, and it can fail outside a secure context. */}
+                <pre className={tool.multiline ? 'is-block' : undefined}>
+                  <code>{tool.snippet}</code>
+                </pre>
+              </div>
+
+              {tool.url ? (
+                <a className="tool-link" href={tool.url} rel="noreferrer" target="_blank">
+                  {card.linkLabel}
+                </a>
+              ) : null}
+            </m.article>
+          ))}
+        </AnimatePresence>
+      </div>
+      {visibleTools.length === 0 ? <p className="tools-empty">{grid.emptyFilteredState}</p> : null}
+    </>
+  )
+}
+
+export { ToolGrid }

--- a/apps/frontend/src/app/(site)/outils-ia/_content.ts
+++ b/apps/frontend/src/app/(site)/outils-ia/_content.ts
@@ -1,0 +1,43 @@
+/**
+ * Static editorial copy and metadata for the AI tooling page.
+ *
+ * The tools themselves come from Payload — this file only holds strings tied to
+ * the page's structure.
+ */
+export const OUTILS_IA_CONTENT = {
+  metadata: {
+    title: 'Outils IA',
+    description: 'Les skills, plugins et serveurs MCP que j’utilise au quotidien, prêts à copier.',
+  },
+  heading: {
+    eyebrow: 'Outils IA',
+    title: 'Mes skills, plugins et MCP, prêts à copier.',
+    lead: 'Ce que j’installe sur mes propres postes. Chaque carte porte sa commande ou sa configuration : un clic sur « Copier » et c’est dans ton presse-papier.',
+  },
+  filter: {
+    allKinds: 'Tous',
+    ariaLabel: 'Filtrer par type d’outil',
+  },
+  /** Filter labels and the caption above each snippet, per kind. */
+  kinds: {
+    skill: { label: 'Skills', snippetLabel: 'Commande d’installation' },
+    plugin: { label: 'Plugins', snippetLabel: 'Commande d’installation' },
+    mcp: { label: 'MCP', snippetLabel: 'Configuration' },
+  },
+  copy: {
+    idle: 'Copier',
+    done: 'Copié',
+    failed: 'Échec',
+    /** Accessible name: the visible label alone repeats across every card. */
+    ariaLabel: (name: string) => `Copier le contenu de ${name}`,
+    unavailable:
+      'La copie automatique est indisponible ici. Sélectionne le texte pour le copier à la main.',
+  },
+  card: {
+    linkLabel: 'Documentation',
+  },
+  grid: {
+    emptyState: 'Aucun outil publié pour l’instant.',
+    emptyFilteredState: 'Aucun outil de ce type pour l’instant.',
+  },
+} as const

--- a/apps/frontend/src/app/(site)/outils-ia/_styles.css
+++ b/apps/frontend/src/app/(site)/outils-ia/_styles.css
@@ -1,0 +1,165 @@
+.tools-filters {
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+.tools-filters button {
+  padding: var(--spacing-2xs) 13px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    background-color var(--duration-fast) ease;
+}
+.tools-filters button:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.tools-filters button.is-active {
+  border-color: var(--accent-solid);
+  background: var(--accent-solid);
+  color: white;
+}
+
+/*
+ * Wider minimum than the veille grid: these cards hold a command line, and a
+ * narrower column would wrap almost every snippet.
+ */
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--spacing-md);
+}
+.tool-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  transition:
+    border-color var(--duration-base) ease,
+    box-shadow var(--duration-base) ease;
+}
+.tool-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 14px 34px rgb(18 24 40 / 10%);
+}
+.tool-card-head h2 {
+  margin: var(--spacing-2xs) 0 0;
+  font-size: var(--text-base);
+}
+.tool-card-head p {
+  margin: var(--spacing-2xs) 0 0;
+  color: var(--muted);
+  font-size: var(--text-xs);
+  line-height: 1.55;
+}
+
+.tool-kind {
+  display: inline-block;
+  padding: 3px var(--spacing-xs);
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.tool-kind-skill {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg));
+  color: var(--accent-solid);
+}
+.tool-kind-plugin {
+  background: color-mix(in srgb, #3ecf8e 16%, var(--bg));
+  color: #17795a;
+}
+.tool-kind-mcp {
+  background: color-mix(in srgb, #6d8cff 16%, var(--bg));
+  color: #3355c8;
+}
+
+.tool-snippet {
+  margin-top: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.tool-snippet-head {
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2xs) var(--spacing-xs) var(--spacing-2xs) var(--spacing-sm);
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 11px;
+}
+.tool-snippet pre {
+  margin: 0;
+  padding: var(--spacing-sm);
+  overflow-x: auto;
+  color: var(--text);
+  font-size: var(--text-2xs);
+  line-height: 1.5;
+  /*
+   * One-line snippets keep their own line and scroll sideways rather than wrap,
+   * so a command stays readable as a single unit. Config blocks keep the line
+   * breaks they were written with.
+   */
+  white-space: pre;
+}
+.tool-snippet pre.is-block {
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.copy-button {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: var(--spacing-3xs);
+  align-items: center;
+  padding: var(--spacing-3xs) var(--spacing-xs);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 11px;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+.copy-button:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.copy-button.is-done {
+  border-color: #3ecf8e;
+  color: #17795a;
+}
+.copy-button.is-failed {
+  border-color: #e5484d;
+  color: #e5484d;
+}
+
+.tool-link {
+  color: var(--muted);
+  font-size: var(--text-2xs);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.tool-link:hover {
+  color: var(--text);
+}
+
+.tools-empty {
+  padding: var(--spacing-xl) 0;
+  color: var(--muted);
+  font-size: var(--text-sm);
+  text-align: center;
+}

--- a/apps/frontend/src/app/(site)/outils-ia/page.tsx
+++ b/apps/frontend/src/app/(site)/outils-ia/page.tsx
@@ -1,0 +1,26 @@
+import { listPublicAITools } from '@/lib/ai-tools'
+
+import { ToolGrid } from './_components/tool-grid'
+import { OUTILS_IA_CONTENT } from './_content'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = OUTILS_IA_CONTENT.metadata
+
+async function AIToolsPage() {
+  const tools = await listPublicAITools()
+  const { heading } = OUTILS_IA_CONTENT
+
+  return (
+    <div className="page shell">
+      <header className="page-heading">
+        <p className="eyebrow">{heading.eyebrow}</p>
+        <h1>{heading.title}</h1>
+        <p>{heading.lead}</p>
+      </header>
+      <ToolGrid tools={tools} />
+    </div>
+  )
+}
+
+export { AIToolsPage as default }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -208,5 +208,6 @@ img {
 @import '../styles/responsive.css';
 @import '../styles/motion.css';
 @import './(site)/veille/_styles.css';
+@import './(site)/outils-ia/_styles.css';
 @import './(site)/a-propos/_styles.css';
 @import '../styles/overrides.css';

--- a/apps/frontend/src/cms/collections/ai-tools.ts
+++ b/apps/frontend/src/cms/collections/ai-tools.ts
@@ -1,0 +1,116 @@
+import { CONTENT_TAGS, revalidateCollection } from '@/lib/content-cache'
+
+import type { CollectionConfig } from 'payload'
+
+const revalidate = revalidateCollection(CONTENT_TAGS.aiTools)
+
+/**
+ * AI tooling I keep at hand: Claude Code skills, plugins and MCP servers.
+ *
+ * The point of the page is the `snippet` field. Everything else is context that
+ * helps a visitor decide whether the snippet is worth copying; the snippet is
+ * what they actually leave with.
+ *
+ * A single collection with a `kind` select rather than three collections: the
+ * three types differ only by the label above the snippet, and sharing one shape
+ * is what lets the page offer a single filter row over all of them.
+ *
+ * Writing is restricted to the signed-in admin, exactly like `bookmarks`: the
+ * page is public to read and closed to contributions.
+ */
+const AITools: CollectionConfig = {
+  slug: 'ai-tools',
+  labels: { singular: 'Outil IA', plural: 'Outils IA' },
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'kind', 'active', 'updatedAt'],
+    description: 'Skills, plugins et serveurs MCP affichés sur /outils-ia.',
+  },
+  access: {
+    read: () => true,
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+    delete: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      label: 'Nom',
+      required: true,
+    },
+    {
+      name: 'kind',
+      type: 'select',
+      label: 'Type',
+      required: true,
+      index: true,
+      defaultValue: 'skill',
+      options: [
+        { label: 'Skill', value: 'skill' },
+        { label: 'Plugin', value: 'plugin' },
+        { label: 'Serveur MCP', value: 'mcp' },
+      ],
+      admin: {
+        description: 'Décide du filtre sous lequel l’outil apparaît.',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Description',
+      admin: {
+        description: 'Une ou deux phrases : à quoi sert l’outil, pas comment il marche.',
+      },
+    },
+    {
+      name: 'snippet',
+      type: 'textarea',
+      label: 'À copier',
+      required: true,
+      admin: {
+        description:
+          'Commande d’installation pour un skill ou un plugin, bloc de configuration pour un MCP. C’est le contenu du bouton « Copier ».',
+      },
+      validate: (value: string | null | undefined) =>
+        typeof value === 'string' && value.trim() !== ''
+          ? true
+          : 'Un outil sans contenu à copier n’a rien à faire sur la page.',
+    },
+    {
+      name: 'url',
+      type: 'text',
+      label: 'Lien (optionnel)',
+      admin: {
+        description: 'Dépôt ou documentation. Affiché en lien discret sur la carte.',
+      },
+      validate: (value: string | null | undefined) => {
+        if (typeof value !== 'string' || value.trim() === '') return true
+        try {
+          const { protocol } = new URL(value)
+          return protocol === 'http:' || protocol === 'https:'
+            ? true
+            : 'Le lien doit être en http(s).'
+        } catch {
+          return 'Cette adresse n’est pas une URL valide.'
+        }
+      },
+    },
+    {
+      name: 'active',
+      type: 'checkbox',
+      label: 'Visible sur le site',
+      defaultValue: true,
+      index: true,
+      admin: {
+        description: 'Décochez pour retirer l’outil du site sans le supprimer.',
+      },
+    },
+  ],
+  hooks: {
+    afterChange: [revalidate.afterChange],
+    afterDelete: [revalidate.afterDelete],
+  },
+}
+
+export { AITools }

--- a/apps/frontend/src/cms/migrations/20260824_203553_ai_tools.json
+++ b/apps/frontend/src/cms/migrations/20260824_203553_ai_tools.json
@@ -1,0 +1,2747 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_id": {
+          "name": "cover_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_url_idx": {
+          "name": "projects_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_idx": {
+          "name": "projects_cover_idx",
+          "columns": [
+            {
+              "expression": "cover_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_order_idx": {
+          "name": "projects_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_cover_id_media_id_fk": {
+          "name": "projects_cover_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": ["cover_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_texts": {
+      "name": "projects_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_texts_order_parent": {
+          "name": "projects_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_texts_parent_fk": {
+          "name": "projects_texts_parent_fk",
+          "tableFrom": "projects_texts",
+          "tableTo": "projects",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_achievements": {
+      "name": "experiences_achievements",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_achievements_order_idx": {
+          "name": "experiences_achievements_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_achievements_parent_id_idx": {
+          "name": "experiences_achievements_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_achievements_parent_id_fk": {
+          "name": "experiences_achievements_parent_id_fk",
+          "tableFrom": "experiences_achievements",
+          "tableTo": "experiences",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences": {
+      "name": "experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current": {
+          "name": "current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project": {
+          "name": "project",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "experiences_start_date_idx": {
+          "name": "experiences_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_updated_at_idx": {
+          "name": "experiences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_created_at_idx": {
+          "name": "experiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_texts": {
+      "name": "experiences_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiences_texts_order_parent": {
+          "name": "experiences_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_texts_parent_fk": {
+          "name": "experiences_texts_parent_fk",
+          "tableFrom": "experiences_texts",
+          "tableTo": "experiences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_url_idx": {
+          "name": "bookmarks_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_domain_idx": {
+          "name": "bookmarks_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_active_idx": {
+          "name": "bookmarks_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_updated_at_idx": {
+          "name": "bookmarks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_created_at_idx": {
+          "name": "bookmarks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks_rels": {
+      "name": "bookmarks_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_rels_order_idx": {
+          "name": "bookmarks_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_parent_idx": {
+          "name": "bookmarks_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_path_idx": {
+          "name": "bookmarks_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_tags_id_idx": {
+          "name": "bookmarks_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_rels_parent_fk": {
+          "name": "bookmarks_rels_parent_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_rels_tags_fk": {
+          "name": "bookmarks_rels_tags_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_knowledge": {
+      "name": "ai_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "enum_ai_knowledge_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'parcours'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_knowledge_updated_at_idx": {
+          "name": "ai_knowledge_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_knowledge_created_at_idx": {
+          "name": "ai_knowledge_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_ai_tools_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_kind_idx": {
+          "name": "ai_tools_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_active_idx": {
+          "name": "ai_tools_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_updated_at_idx": {
+          "name": "ai_tools_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_created_at_idx": {
+          "name": "ai_tools_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projects_id": {
+          "name": "projects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences_id": {
+          "name": "experiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarks_id": {
+          "name": "bookmarks_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_knowledge_id": {
+          "name": "ai_knowledge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tools_id": {
+          "name": "ai_tools_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_projects_id_idx": {
+          "name": "payload_locked_documents_rels_projects_id_idx",
+          "columns": [
+            {
+              "expression": "projects_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_experiences_id_idx": {
+          "name": "payload_locked_documents_rels_experiences_id_idx",
+          "columns": [
+            {
+              "expression": "experiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_bookmarks_id_idx": {
+          "name": "payload_locked_documents_rels_bookmarks_id_idx",
+          "columns": [
+            {
+              "expression": "bookmarks_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_knowledge_id_idx": {
+          "name": "payload_locked_documents_rels_ai_knowledge_id_idx",
+          "columns": [
+            {
+              "expression": "ai_knowledge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_tools_id_idx": {
+          "name": "payload_locked_documents_rels_ai_tools_id_idx",
+          "columns": [
+            {
+              "expression": "ai_tools_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_projects_fk": {
+          "name": "payload_locked_documents_rels_projects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "projects",
+          "columnsFrom": ["projects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_experiences_fk": {
+          "name": "payload_locked_documents_rels_experiences_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "experiences",
+          "columnsFrom": ["experiences_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_bookmarks_fk": {
+          "name": "payload_locked_documents_rels_bookmarks_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmarks_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_knowledge_fk": {
+          "name": "payload_locked_documents_rels_ai_knowledge_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_knowledge",
+          "columnsFrom": ["ai_knowledge_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_tools_fk": {
+          "name": "payload_locked_documents_rels_ai_tools_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_tools",
+          "columnsFrom": ["ai_tools_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_identity": {
+      "name": "site_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_display_name": {
+          "name": "contact_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_role": {
+          "name": "contact_role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_location": {
+          "name": "contact_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_github_url": {
+          "name": "social_github_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_linkedin_url": {
+          "name": "social_linkedin_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_publisher": {
+          "name": "legal_publisher",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_name": {
+          "name": "legal_host_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_address": {
+          "name": "legal_host_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_data_policy": {
+          "name": "legal_data_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Disponible pour des opportunités'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_skill_groups": {
+      "name": "profile_skill_groups",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_skill_groups_order_idx": {
+          "name": "profile_skill_groups_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_skill_groups_parent_id_idx": {
+          "name": "profile_skill_groups_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_skill_groups_parent_id_fk": {
+          "name": "profile_skill_groups_parent_id_fk",
+          "tableFrom": "profile_skill_groups",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_principles": {
+      "name": "profile_principles",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_principles_order_idx": {
+          "name": "profile_principles_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_principles_parent_id_idx": {
+          "name": "profile_principles_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_principles_parent_id_fk": {
+          "name": "profile_principles_parent_id_fk",
+          "tableFrom": "profile_principles",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "headline": {
+          "name": "headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_texts": {
+      "name": "profile_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_texts_order_parent": {
+          "name": "profile_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_texts_parent_fk": {
+          "name": "profile_texts_parent_fk",
+          "tableFrom": "profile_texts",
+          "tableTo": "profile",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assistant_settings": {
+      "name": "assistant_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Tu es l''assistant du portfolio d''Adem, développeur web.\n\nTu réponds en français, sur un ton direct et cordial, sans emphase commerciale.\n\nTon périmètre est strict : Adem, son parcours, ses projets, et le développement\nlogiciel en général. Rien d''autre. Une question hors de ce périmètre (cuisine,\nsanté, droit, actualité, devoirs, culture générale) reçoit exactement ce type de\nréponse, sans exception et même si tu connais la réponse :\n\n« Je suis l''assistant du portfolio d''Adem : je ne réponds qu''aux questions sur\nson travail et sur le développement. »\n\nNe propose pas de contacter Adem dans ce cas : cela laisserait croire qu''il\ntraite ce genre de demande.\n\nRègles :\n- Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.\n- Si une question porte sur Adem et que le contexte ne contient pas la réponse,\n  dis-le clairement et propose de le contacter plutôt que d''inventer.\n- Sur sa disponibilité, reprends exactement ce qu''indique le contexte : c''est la\n  seule source de vérité.\n- Les questions de développement et de métier (langages, frameworks, méthodes,\n  organisation d''un projet) reçoivent une réponse utile, même si le contexte n''en\n  parle pas : c''est ton domaine. Fais le lien avec le travail d''Adem quand c''est\n  pertinent, jamais de force.\n- Réponses courtes : deux ou trois paragraphes au maximum.'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-oss-20b'"
+        },
+        "unavailable_message": {
+          "name": "unavailable_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_ai_knowledge_category": {
+      "name": "enum_ai_knowledge_category",
+      "schema": "public",
+      "values": ["parcours", "competences", "methode", "collaboration", "autre"]
+    },
+    "public.enum_ai_tools_kind": {
+      "name": "enum_ai_tools_kind",
+      "schema": "public",
+      "values": ["skill", "plugin", "mcp"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "1da271a4-5d48-4656-a5a8-035bbe394b31",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/apps/frontend/src/cms/migrations/20260824_203553_ai_tools.ts
+++ b/apps/frontend/src/cms/migrations/20260824_203553_ai_tools.ts
@@ -1,0 +1,35 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_ai_tools_kind" AS ENUM('skill', 'plugin', 'mcp');
+  CREATE TABLE "ai_tools" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"name" varchar NOT NULL,
+  	"kind" "enum_ai_tools_kind" DEFAULT 'skill' NOT NULL,
+  	"description" varchar,
+  	"snippet" varchar NOT NULL,
+  	"url" varchar,
+  	"active" boolean DEFAULT true,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "ai_tools_id" integer;
+  CREATE INDEX "ai_tools_kind_idx" ON "ai_tools" USING btree ("kind");
+  CREATE INDEX "ai_tools_active_idx" ON "ai_tools" USING btree ("active");
+  CREATE INDEX "ai_tools_updated_at_idx" ON "ai_tools" USING btree ("updated_at");
+  CREATE INDEX "ai_tools_created_at_idx" ON "ai_tools" USING btree ("created_at");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_ai_tools_fk" FOREIGN KEY ("ai_tools_id") REFERENCES "public"."ai_tools"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_ai_tools_id_idx" ON "payload_locked_documents_rels" USING btree ("ai_tools_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "ai_tools" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "ai_tools" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_ai_tools_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_ai_tools_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "ai_tools_id";
+  DROP TYPE "public"."enum_ai_tools_kind";`)
+}

--- a/apps/frontend/src/cms/migrations/index.ts
+++ b/apps/frontend/src/cms/migrations/index.ts
@@ -5,6 +5,7 @@ import * as migration_20260817_124153_real_content from './20260817_124153_real_
 import * as migration_20260817_155900_display_name from './20260817_155900_display_name'
 import * as migration_20260818_135519_availability from './20260818_135519_availability'
 import * as migration_20260818_141706_assistant from './20260818_141706_assistant'
+import * as migration_20260824_203553_ai_tools from './20260824_203553_ai_tools'
 
 export const migrations = [
   {
@@ -41,5 +42,10 @@ export const migrations = [
     up: migration_20260818_141706_assistant.up,
     down: migration_20260818_141706_assistant.down,
     name: '20260818_141706_assistant',
+  },
+  {
+    up: migration_20260824_203553_ai_tools.up,
+    down: migration_20260824_203553_ai_tools.down,
+    name: '20260824_203553_ai_tools',
   },
 ]

--- a/apps/frontend/src/cms/payload.config.ts
+++ b/apps/frontend/src/cms/payload.config.ts
@@ -7,6 +7,7 @@ import { buildConfig } from 'payload'
 import sharp from 'sharp'
 
 import { AIKnowledge } from './collections/ai-knowledge'
+import { AITools } from './collections/ai-tools'
 import { Bookmarks } from './collections/bookmarks'
 import { Experiences } from './collections/experiences'
 import { Media } from './collections/media'
@@ -28,7 +29,7 @@ export default buildConfig({
       titleSuffix: '— Adem',
     },
   },
-  collections: [Users, Media, Projects, Experiences, Tags, Bookmarks, AIKnowledge],
+  collections: [Users, Media, Projects, Experiences, Tags, Bookmarks, AIKnowledge, AITools],
   globals: [SiteIdentity, Availability, Profile, AssistantSettings],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET ?? '',

--- a/apps/frontend/src/components/site-nav.tsx
+++ b/apps/frontend/src/components/site-nav.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: '/', label: 'Accueil' },
   { href: '/projets', label: 'Projets' },
   { href: '/veille', label: 'Veille' },
+  { href: '/outils-ia', label: 'Outils IA' },
   { href: '/a-propos', label: 'À propos' },
   { href: '/contact', label: 'Contact' },
 ]

--- a/apps/frontend/src/lib/ai-tools.ts
+++ b/apps/frontend/src/lib/ai-tools.ts
@@ -1,0 +1,80 @@
+import { getPayload } from 'payload'
+
+import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
+import config from '@payload-config'
+
+import type { AiTool } from '@/payload-types'
+
+/**
+ * Server-side access to the AI tooling list.
+ *
+ * Same shape as `lib/bookmarks.ts`: Payload is queried locally from the server
+ * component, and the read is cached under a tag purged on write.
+ */
+
+/** Derived from the collection rather than restated: Payload owns this union. */
+type AIToolKind = AiTool['kind']
+
+/** Minimal shape the view needs, decoupled from the Payload-generated types. */
+interface AIToolView {
+  id: string
+  name: string
+  kind: AIToolKind
+  description: string | null
+  /** The text behind the copy button — the reason the page exists. */
+  snippet: string
+  url: string | null
+  /**
+   * True when the snippet spans several lines, which is what separates a config
+   * block from a one-line install command. The view renders them differently and
+   * this is the only signal it needs, so the distinction is computed once here
+   * rather than re-derived in the browser.
+   */
+  multiline: boolean
+}
+
+const asText = (value: string | null | undefined): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+const toView = (doc: AiTool): AIToolView => {
+  const snippet = (doc.snippet ?? '').trim()
+
+  return {
+    id: String(doc.id),
+    name: doc.name,
+    kind: doc.kind,
+    description: asText(doc.description),
+    snippet,
+    url: asText(doc.url),
+    multiline: snippet.includes('\n'),
+  }
+}
+
+/**
+ * Lists the tools visible on the site, grouped by kind at render time.
+ *
+ * Sorted by name rather than by creation date: unlike a veille feed, this list is
+ * a reference one comes back to, so a stable alphabetical order is easier to scan
+ * than a shifting "most recent first".
+ */
+const readPublicAITools = async (): Promise<AIToolView[]> => {
+  const payload = await getPayload({ config })
+
+  const result = await payload.find({
+    collection: 'ai-tools',
+    where: { active: { equals: true } },
+    sort: 'name',
+    limit: 200,
+    depth: 0,
+    overrideAccess: false,
+  })
+
+  return result.docs.map(toView)
+}
+
+const listPublicAITools = cachedRead(CONTENT_TAGS.aiTools, 'ai-tools:list', readPublicAITools)
+
+export { listPublicAITools, type AIToolKind, type AIToolView }

--- a/apps/frontend/src/lib/content-cache.ts
+++ b/apps/frontend/src/lib/content-cache.ts
@@ -29,6 +29,7 @@ const CONTENT_TAGS = {
   experiences: 'content:experiences',
   projects: 'content:projects',
   bookmarks: 'content:bookmarks',
+  aiTools: 'content:ai-tools',
   aiKnowledge: 'content:ai-knowledge',
   assistant: 'content:assistant',
 } as const
@@ -53,6 +54,7 @@ const PAGES_BY_TAG: Record<ContentTag, { path: string; type?: 'layout' | 'page' 
   [CONTENT_TAGS.experiences]: [{ path: '/a-propos' }],
   [CONTENT_TAGS.projects]: [{ path: '/' }, { path: '/projets' }],
   [CONTENT_TAGS.bookmarks]: [{ path: '/' }, { path: '/veille' }],
+  [CONTENT_TAGS.aiTools]: [{ path: '/outils-ia' }],
   // The assistant answers from a route handler, so no page holds this content:
   // purging the cache entry is enough, there is no HTML to replace.
   [CONTENT_TAGS.aiKnowledge]: [],

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     tags: Tag
     bookmarks: Bookmark
     'ai-knowledge': AiKnowledge
+    'ai-tools': AiTool
     'payload-kv': PayloadKv
     'payload-locked-documents': PayloadLockedDocument
     'payload-preferences': PayloadPreference
@@ -88,6 +89,7 @@ export interface Config {
     tags: TagsSelect<false> | TagsSelect<true>
     bookmarks: BookmarksSelect<false> | BookmarksSelect<true>
     'ai-knowledge': AiKnowledgeSelect<false> | AiKnowledgeSelect<true>
+    'ai-tools': AiToolsSelect<false> | AiToolsSelect<true>
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>
     'payload-locked-documents':
       | PayloadLockedDocumentsSelect<false>
@@ -350,6 +352,38 @@ export interface AiKnowledge {
   createdAt: string
 }
 /**
+ * Skills, plugins et serveurs MCP affichés sur /outils-ia.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ai-tools".
+ */
+export interface AiTool {
+  id: number
+  name: string
+  /**
+   * Décide du filtre sous lequel l’outil apparaît.
+   */
+  kind: 'skill' | 'plugin' | 'mcp'
+  /**
+   * Une ou deux phrases : à quoi sert l’outil, pas comment il marche.
+   */
+  description?: string | null
+  /**
+   * Commande d’installation pour un skill ou un plugin, bloc de configuration pour un MCP. C’est le contenu du bouton « Copier ».
+   */
+  snippet: string
+  /**
+   * Dépôt ou documentation. Affiché en lien discret sur la carte.
+   */
+  url?: string | null
+  /**
+   * Décochez pour retirer l’outil du site sans le supprimer.
+   */
+  active?: boolean | null
+  updatedAt: string
+  createdAt: string
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -400,6 +434,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'ai-knowledge'
         value: number | AiKnowledge
+      } | null)
+    | ({
+        relationTo: 'ai-tools'
+        value: number | AiTool
       } | null)
   globalSlug?: string | null
   user: {
@@ -558,6 +596,20 @@ export interface AiKnowledgeSelect<T extends boolean = true> {
   answer?: T
   category?: T
   published?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ai-tools_select".
+ */
+export interface AiToolsSelect<T extends boolean = true> {
+  name?: T
+  kind?: T
+  description?: T
+  snippet?: T
+  url?: T
+  active?: T
   updatedAt?: T
   createdAt?: T
 }


### PR DESCRIPTION
Closes #62

## Summary

Adds `/outils-ia`, a reference page listing the skills, plugins and MCP servers used day to day. Each card carries its install command or configuration block behind a copy button, so reinstalling a tool on a fresh machine is one click instead of a search through scattered notes.

## Design decisions

**One collection, not three.** Skills, plugins and MCP servers share every field and differ only in the label shown above the snippet ("Commande d'installation" vs "Configuration"). A `kind` select covers that difference; three collections would have tripled the schema and the migration surface for no gain.

**Read-only for visitors is enforced by access control, not by the UI.** `ai-tools` mirrors the `bookmarks` pattern: `read: () => true`, every write conditioned on `req.user`. The API refuses an unauthenticated write rather than the frontend merely not offering a form.

**The copy button is a shortcut, not the only path.** The snippet renders inside a selectable `<pre><code>`. Clipboard writes require a secure context and user activation, so the button surfaces an explicit failure state ("Échec", reset after 1.8s) when either is missing — the content stays reachable by selection either way.

**`multiline` is computed server-side.** A one-line install command and a multi-line JSON config need different rendering (horizontal scroll vs a capped scrollable block). Deriving that once on the server avoids shipping the branch to the client.

## Changes

| Layer | File |
|---|---|
| Collection | `src/cms/collections/ai-tools.ts` — `name`, `kind`, `description`, `snippet`, `url`, `active` |
| Migration | `src/cms/migrations/20260824_203553_ai_tools.ts` |
| Read layer | `src/lib/ai-tools.ts` — alphabetical sort, cached under `content:ai-tools` |
| Page | `src/app/(site)/outils-ia/` — `page.tsx`, `_components/`, `_content.ts`, `_styles.css` |
| Cache | `src/lib/content-cache.ts` — new tag + `/outils-ia` revalidation mapping |
| Nav | `src/components/site-nav.tsx` — "Outils IA" entry |

Publishing from `/admin` revalidates `/outils-ia` through the collection hooks, so content changes land without a redeploy.

## Test plan

- [x] `pnpm type-check --filter @portfolio/frontend` — passes
- [x] `pnpm lint --filter @portfolio/frontend` — passes
- [x] Migration applied locally (batch 8), reviewed for unrelated drift before applying
- [x] Page renders all seeded tools with the correct per-kind snippet label
- [x] Kind filter verified across all four states (Tous / Skills / Plugins / MCP)
- [x] Clipboard write confirmed on real user-activated clicks
- [x] Failure path confirmed (scripted click without user activation → "Échec", auto-reset)
- [x] Zero console errors

## Validation results

Type-check and lint both green. The migration was inspected before applying and stripped of an unrelated `assistant_settings.system_prompt` default that local DB drift had pulled into the generated file — its `down()` would have restored an older prompt.

## Notes for review

The tools currently in the local database are sample data and are **not** part of this diff — real content gets entered through `/admin`.
