### PR TITLE
feat(backend): harden the Payload admin and wire password recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,11 @@ GROQ_API_KEY=""
 AI_PROVIDER=""
 
 # --- Email transactionnel (Lumail) ---
-# Jeton d'API Lumail, utilisé par le formulaire de contact.
+# Jeton d'API Lumail, utilisé par le formulaire de contact et par la
+# réinitialisation du mot de passe de l'administration.
 # Générez-le depuis votre organisation Lumail (Settings > API tokens).
-# Sans jeton, le formulaire refuse l'envoi au lieu d'échouer silencieusement.
+# Sans jeton, le formulaire refuse l'envoi au lieu d'échouer silencieusement et
+# la réinitialisation du mot de passe reste indisponible.
 LUMAIL_API_TOKEN=""
 
 # Adresse d'expédition, sur un domaine vérifié dans Lumail (SPF/DKIM posés).
@@ -55,4 +57,6 @@ LUMAIL_FROM_EMAIL=""
 LUMAIL_FROM_NAME="Portfolio"
 
 # Adresse qui reçoit les messages du formulaire de contact.
+# Sans elle, seul le formulaire est désactivé : la réinitialisation du mot de
+# passe écrit au compte concerné, elle n'a pas de destinataire fixe.
 CONTACT_TO_EMAIL=""

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -21,7 +21,8 @@ GROQ_API_KEY=""
 # Fournisseur d'IA. Seul « groq » est implémenté ; vide = « groq ».
 AI_PROVIDER=""
 
-# Email transactionnel (Lumail) — voir le .env.example racine pour le détail.
+# Email transactionnel (Lumail) — formulaire de contact et réinitialisation du
+# mot de passe de l'administration. Voir le .env.example racine pour le détail.
 LUMAIL_API_TOKEN=""
 LUMAIL_FROM_EMAIL=""
 LUMAIL_FROM_NAME="Portfolio"

--- a/apps/frontend/src/cms/collections/users.test.ts
+++ b/apps/frontend/src/cms/collections/users.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { Users } from './users'
+
+import type { PayloadRequest } from 'payload'
+
+/** The collection declares `auth` as an object; this narrows it for the assertions. */
+const auth = typeof Users.auth === 'object' ? Users.auth : null
+
+/**
+ * These assertions guard configuration, not behaviour, and that is deliberate:
+ * every value here is one an upstream default would otherwise decide silently.
+ * A Payload upgrade that raises the brute-force ceiling, or a refactor that drops
+ * the reset template and falls back to the HTML one the transport cannot render,
+ * fails here instead of in production.
+ */
+describe('collection users', () => {
+  it('plafonne les tentatives de connexion', () => {
+    expect(auth?.maxLoginAttempts).toBe(5)
+  })
+
+  it('verrouille le compte dix minutes', () => {
+    expect(auth?.lockTime).toBe(600_000)
+  })
+
+  it('n’ouvre la création de compte qu’à une session authentifiée', () => {
+    const create = Users.access?.create
+
+    expect(create?.({ req: {} } as Parameters<NonNullable<typeof create>>[0])).toBe(false)
+  })
+
+  it('compose lui-même le message de réinitialisation', async () => {
+    const req = { origin: 'https://adem.dev' } as PayloadRequest
+    const body = await auth?.forgotPassword?.generateEmailHTML?.({ req, token: 'tok' })
+
+    expect(body).toContain('https://adem.dev/admin/reset/tok')
+  })
+
+  it('donne un sujet au message de réinitialisation', async () => {
+    const subject = await auth?.forgotPassword?.generateEmailSubject?.({})
+
+    expect(subject).toMatch(/mot de passe/i)
+  })
+})

--- a/apps/frontend/src/cms/collections/users.ts
+++ b/apps/frontend/src/cms/collections/users.ts
@@ -1,3 +1,5 @@
+import { buildResetPasswordEmail, RESET_PASSWORD_SUBJECT } from '../emails/reset-password'
+
 import type { CollectionConfig } from 'payload'
 
 /**
@@ -10,7 +12,23 @@ const Users: CollectionConfig = {
     singular: 'Utilisateur',
     plural: 'Utilisateurs',
   },
-  auth: true,
+  auth: {
+    /**
+     * Lockout policy, written down rather than inherited.
+     *
+     * These two happen to match Payload's current defaults, and that is the
+     * point: a brute-force ceiling that lives in a framework default is one
+     * upgrade away from changing without anyone noticing. Five attempts then ten
+     * minutes of lockout is the decision, and it is reviewable here.
+     */
+    maxLoginAttempts: 5,
+    lockTime: 10 * 60 * 1000,
+    forgotPassword: {
+      generateEmailSubject: () => RESET_PASSWORD_SUBJECT,
+      generateEmailHTML: (args) =>
+        buildResetPasswordEmail({ token: args?.token, requestOrigin: args?.req?.origin }),
+    },
+  },
   admin: {
     useAsTitle: 'email',
     defaultColumns: ['email', 'name', 'updatedAt'],

--- a/apps/frontend/src/cms/emails/reset-password.test.ts
+++ b/apps/frontend/src/cms/emails/reset-password.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { buildResetPasswordEmail, RESET_PASSWORD_SUBJECT } from './reset-password'
+
+const TOKEN = 'a1b2c3'
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_SERVER_URL
+})
+
+/**
+ * The message is worth testing for one reason: a reset link that points at the
+ * wrong host is a dead account. The rest is prose.
+ */
+describe('buildResetPasswordEmail', () => {
+  it('construit le lien sur l’origine de la requête', () => {
+    const body = buildResetPasswordEmail({ token: TOKEN, requestOrigin: 'https://adem.dev' })
+
+    expect(body).toContain(`https://adem.dev/admin/reset/${TOKEN}`)
+  })
+
+  it('préfère l’origine de la requête à l’environnement', () => {
+    process.env.NEXT_PUBLIC_SERVER_URL = 'https://staging.adem.dev'
+
+    const body = buildResetPasswordEmail({ token: TOKEN, requestOrigin: 'https://adem.dev' })
+
+    expect(body).toContain('https://adem.dev/admin/reset/')
+    expect(body).not.toContain('staging')
+  })
+
+  it('retombe sur l’environnement hors contexte de requête', () => {
+    process.env.NEXT_PUBLIC_SERVER_URL = 'https://adem.dev'
+
+    expect(buildResetPasswordEmail({ token: TOKEN })).toContain(
+      `https://adem.dev/admin/reset/${TOKEN}`
+    )
+  })
+
+  it('retombe sur l’hôte local quand rien n’est configuré', () => {
+    expect(buildResetPasswordEmail({ token: TOKEN })).toContain(
+      `http://localhost:3000/admin/reset/${TOKEN}`
+    )
+  })
+
+  it('écrit l’URL seule sur sa ligne, sans balise', () => {
+    const body = buildResetPasswordEmail({ token: TOKEN, requestOrigin: 'https://adem.dev' })
+
+    expect(body).not.toContain('<a')
+    expect(body.split('\n')).toContain(`https://adem.dev/admin/reset/${TOKEN}`)
+  })
+
+  it('annonce l’expiration et la marche à suivre en cas de demande non sollicitée', () => {
+    const body = buildResetPasswordEmail({ token: TOKEN })
+
+    expect(body).toContain('expire')
+    expect(body).toContain('ignorez ce message')
+  })
+
+  it('porte un sujet explicite', () => {
+    expect(RESET_PASSWORD_SUBJECT).toMatch(/mot de passe/i)
+  })
+})

--- a/apps/frontend/src/cms/emails/reset-password.ts
+++ b/apps/frontend/src/cms/emails/reset-password.ts
@@ -1,0 +1,66 @@
+/**
+ * The password reset message.
+ *
+ * Payload ships its own template, and it is replaced for two reasons. It is
+ * written as HTML, while the transport posts markdown — an `<a>` tag would reach
+ * the inbox as visible tag soup. And it is worded for an application with users,
+ * whereas this admin has exactly one account: its owner, who needs the link and
+ * the expiry, not an introduction.
+ *
+ * The field Payload fills is still called `html`; what goes into it here is
+ * markdown, which is what `lib/email/payload.ts` forwards untouched.
+ */
+
+/** Where the admin serves the reset screen. Mirrors Payload's default routes, which the config does not override. */
+const RESET_PATH = '/admin/reset'
+
+const RESET_PASSWORD_SUBJECT = 'Réinitialisation de votre mot de passe'
+
+/**
+ * Resolves the site's own address.
+ *
+ * The request origin comes first because it is the address actually being
+ * browsed, which is what makes the link work behind a proxy or on a preview
+ * domain. The environment is the fallback for a reset triggered outside a
+ * request — a script, the local CLI.
+ */
+const resolveOrigin = (requestOrigin?: string): string => {
+  // A blank candidate counts as absent: `NEXT_PUBLIC_SERVER_URL=""` copied from
+  // .env.example must not win over the fallback and produce a link to nowhere.
+  const configured = [requestOrigin, process.env.NEXT_PUBLIC_SERVER_URL]
+    .map((candidate) => candidate?.trim())
+    .find((candidate) => candidate)
+
+  return configured ?? 'http://localhost:3000'
+}
+
+/**
+ * Builds the message body.
+ *
+ * The URL is written on its own line rather than behind a label: mail clients
+ * linkify a bare URL, and a reader who has to check where a reset link points
+ * can read it without hovering.
+ */
+const buildResetPasswordEmail = ({
+  token,
+  requestOrigin,
+}: {
+  token?: string
+  requestOrigin?: string
+}): string => {
+  const url = `${resolveOrigin(requestOrigin)}${RESET_PATH}/${token ?? ''}`
+
+  return [
+    'Une réinitialisation du mot de passe a été demandée pour ce compte.',
+    '',
+    'Ouvrez ce lien pour en choisir un nouveau :',
+    '',
+    url,
+    '',
+    'Le lien expire dans une heure.',
+    '',
+    "Si vous n'êtes pas à l'origine de cette demande, ignorez ce message : le mot de passe actuel reste valable.",
+  ].join('\n')
+}
+
+export { buildResetPasswordEmail, RESET_PASSWORD_SUBJECT }

--- a/apps/frontend/src/cms/payload.config.ts
+++ b/apps/frontend/src/cms/payload.config.ts
@@ -6,6 +6,9 @@ import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { buildConfig } from 'payload'
 import sharp from 'sharp'
 
+import { resolvePayloadEmailAdapter } from '@/lib/email/payload'
+import { requireEnv } from '@/lib/require-env'
+
 import { AIKnowledge } from './collections/ai-knowledge'
 import { AITools } from './collections/ai-tools'
 import { Bookmarks } from './collections/bookmarks'
@@ -32,7 +35,12 @@ export default buildConfig({
   collections: [Users, Media, Projects, Experiences, Tags, Bookmarks, AIKnowledge, AITools],
   globals: [SiteIdentity, Availability, Profile, AssistantSettings],
   editor: lexicalEditor(),
-  secret: process.env.PAYLOAD_SECRET ?? '',
+  // Required, never defaulted: an empty secret signs session cookies and reset
+  // tokens with a value anyone can reproduce. See lib/require-env.
+  secret: requireEnv('PAYLOAD_SECRET'),
+  // Absent when the sending domain is not configured. Payload then reports that
+  // email is unavailable rather than pretending a reset link was delivered.
+  email: resolvePayloadEmailAdapter(),
   typescript: {
     // Generated types live at src/payload-types.ts, one level up from this
     // config, so they resolve through the plain @/payload-types alias.
@@ -40,7 +48,7 @@ export default buildConfig({
   },
   db: postgresAdapter({
     pool: {
-      connectionString: process.env.DATABASE_URI ?? '',
+      connectionString: requireEnv('DATABASE_URI'),
     },
     // Migrations are the single source of truth for the schema: `push` is
     // disabled so dev and production can never drift apart.

--- a/apps/frontend/src/lib/email/index.test.ts
+++ b/apps/frontend/src/lib/email/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveEmailProvider } from './index'
+import { resolveEmailProvider, resolveEmailSender } from './index'
 
 const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
 
@@ -38,5 +38,36 @@ describe('resolveEmailProvider', () => {
 
   it('n’exige pas le nom d’expéditeur, qui n’est que cosmétique', () => {
     expect(resolveEmailProvider(env({ ...COMPLETE, LUMAIL_FROM_NAME: '' }))?.id).toBe('lumail')
+  })
+})
+
+/**
+ * The sender is what everything that composes its own message goes through —
+ * account recovery today. It asks for less than the contact form: no destination
+ * inbox, because the message carries one.
+ */
+describe('resolveEmailSender', () => {
+  it('retourne null quand rien n’est configuré', () => {
+    expect(resolveEmailSender(env({}))).toBeNull()
+  })
+
+  it('n’exige pas le destinataire du formulaire de contact', () => {
+    const { CONTACT_TO_EMAIL: _ignored, ...credentials } = COMPLETE
+
+    expect(resolveEmailSender(env(credentials))?.provider.id).toBe('lumail')
+  })
+
+  it('exige les identifiants et l’adresse d’envoi', () => {
+    for (const missing of ['LUMAIL_API_TOKEN', 'LUMAIL_FROM_EMAIL']) {
+      const partial = { ...COMPLETE, [missing]: '' }
+      expect(resolveEmailSender(env(partial)), `sans ${missing}`).toBeNull()
+    }
+  })
+
+  it('expose l’identité sous laquelle Payload annoncera ses envois', () => {
+    const sender = resolveEmailSender(env({ ...COMPLETE, LUMAIL_FROM_NAME: 'Portfolio' }))
+
+    expect(sender?.fromEmail).toBe('contact@domaine.fr')
+    expect(sender?.fromName).toBe('Portfolio')
   })
 })

--- a/apps/frontend/src/lib/email/index.ts
+++ b/apps/frontend/src/lib/email/index.ts
@@ -1,5 +1,6 @@
 import { createLumailProvider } from './lumail'
 
+import type { LumailCredentials } from './lumail'
 import type { EmailProvider } from './provider'
 
 /**
@@ -11,31 +12,75 @@ import type { EmailProvider } from './provider'
  */
 
 /**
- * Builds the provider, or `null` when the environment does not configure one.
+ * The sender itself, plus the identity it posts under.
  *
- * `null` rather than a throw, mirroring `lib/ai`: a portfolio deployed before its
- * sending domain exists is a deployment state, not a bug. The caller answers it
- * with the mailto fallback, so the page keeps working while the DNS records are
- * still propagating.
- *
- * All three values are required together — a token without a verified `from` is
- * rejected by Lumail, and a `from` without a recipient has nowhere to land.
+ * The address travels with the provider because a caller that composes its own
+ * message still has to announce who it comes from — Payload's email adapter
+ * declares a default `from` up front, before any message exists.
  */
-const resolveEmailProvider = (env: NodeJS.ProcessEnv = process.env): EmailProvider | null => {
+interface EmailSender {
+  provider: EmailProvider
+  fromEmail: string
+  fromName?: string
+}
+
+/**
+ * Reads what it takes to send anything at all.
+ *
+ * A recipient is deliberately not part of it: it belongs to whoever composes the
+ * message, and only the contact form has a fixed one.
+ */
+const resolveCredentials = (env: NodeJS.ProcessEnv): LumailCredentials | null => {
   const apiToken = env.LUMAIL_API_TOKEN?.trim()
   const fromEmail = env.LUMAIL_FROM_EMAIL?.trim()
-  const toEmail = env.CONTACT_TO_EMAIL?.trim()
 
-  if (!apiToken || !fromEmail || !toEmail) return null
+  if (!apiToken || !fromEmail) return null
 
   // Cosmetic, so its absence is not a reason to refuse. A blank value is treated
   // as unset rather than sent as an empty display name.
   const trimmedName = env.LUMAIL_FROM_NAME?.trim()
   const fromName = trimmedName === '' ? undefined : trimmedName
 
-  return createLumailProvider({ apiToken, fromEmail, fromName, toEmail })
+  return { apiToken, fromEmail, fromName }
 }
 
-export { resolveEmailProvider }
+/**
+ * Builds the sender, or `null` when the environment does not configure one.
+ *
+ * `null` rather than a throw, mirroring `lib/ai`: a portfolio deployed before
+ * its sending domain exists is a deployment state, not a bug. Each caller
+ * answers it in its own terms — the contact form with a mailto fallback,
+ * Payload by leaving password recovery unwired.
+ */
+const resolveEmailSender = (env: NodeJS.ProcessEnv = process.env): EmailSender | null => {
+  const credentials = resolveCredentials(env)
+
+  if (!credentials) return null
+
+  return {
+    provider: createLumailProvider(credentials),
+    fromEmail: credentials.fromEmail,
+    fromName: credentials.fromName,
+  }
+}
+
+/**
+ * Builds the provider the contact form uses, or `null` when it cannot send.
+ *
+ * Stricter than `resolveEmailSender`: this one carries the destination inbox, so
+ * `CONTACT_TO_EMAIL` is required alongside the credentials. A token without a
+ * verified `from` is rejected by Lumail, and a `from` without a recipient has
+ * nowhere to land.
+ */
+const resolveEmailProvider = (env: NodeJS.ProcessEnv = process.env): EmailProvider | null => {
+  const credentials = resolveCredentials(env)
+  const toEmail = env.CONTACT_TO_EMAIL?.trim()
+
+  if (!credentials || !toEmail) return null
+
+  return createLumailProvider({ ...credentials, toEmail })
+}
+
+export { resolveEmailProvider, resolveEmailSender }
+export type { EmailSender }
 export { EmailError } from './provider'
-export type { EmailErrorKind, EmailMessage, EmailProvider } from './provider'

--- a/apps/frontend/src/lib/email/lumail.test.ts
+++ b/apps/frontend/src/lib/email/lumail.test.ts
@@ -132,3 +132,36 @@ describe('createLumailProvider', () => {
     })
   })
 })
+
+/**
+ * Recipient resolution. The contact form leans on the configured inbox; account
+ * recovery names its own address, and a provider configured for neither must say
+ * so rather than post a message with no destination.
+ */
+describe('destinataire', () => {
+  it('utilise le destinataire par défaut quand le message n’en nomme aucun', async () => {
+    const spy = stubFetch(jsonResponse(200, { id: 'msg_1' }))
+
+    await createLumailProvider(CONFIG).send(MESSAGE)
+
+    expect(sentBody(spy).to).toBe(CONFIG.toEmail)
+  })
+
+  it('préfère le destinataire porté par le message', async () => {
+    const spy = stubFetch(jsonResponse(200, { id: 'msg_1' }))
+
+    await createLumailProvider(CONFIG).send({ ...MESSAGE, to: 'admin@domaine.fr' })
+
+    expect(sentBody(spy).to).toBe('admin@domaine.fr')
+  })
+
+  it('refuse d’envoyer sans destinataire, sans appeler Lumail', async () => {
+    const spy = stubFetch(jsonResponse(200, { id: 'msg_1' }))
+    const { toEmail: _ignored, ...credentials } = CONFIG
+
+    await expect(createLumailProvider(credentials).send(MESSAGE)).rejects.toMatchObject({
+      kind: 'bad_request' satisfies EmailErrorKind,
+    })
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/lib/email/lumail.ts
+++ b/apps/frontend/src/lib/email/lumail.ts
@@ -15,13 +15,24 @@ import type { EmailMessage, EmailProvider } from './provider'
 
 const ENDPOINT = 'https://lumail.io/api/v1/emails'
 
-interface LumailConfig {
+/** What it takes to reach Lumail at all, independently of any recipient. */
+interface LumailCredentials {
   apiToken: string
   fromEmail: string
   /** Display name shown as the sender. Optional: the address alone is valid. */
   fromName?: string
-  /** Where contact notifications land. Unlike `fromEmail`, any domain works. */
-  toEmail: string
+}
+
+interface LumailConfig extends LumailCredentials {
+  /**
+   * Default recipient, used by every message that does not name one.
+   *
+   * Optional because not every sender has a fixed destination: the contact form
+   * always writes to the same inbox, while account recovery writes to whoever
+   * asked. A provider built without it only accepts messages carrying their own
+   * `to`. Unlike `fromEmail`, any domain works.
+   */
+  toEmail?: string
 }
 
 /**
@@ -65,7 +76,13 @@ const createLumailProvider = ({
   toEmail,
 }: LumailConfig): EmailProvider => ({
   id: 'lumail',
-  send: async ({ subject, text, replyTo }: EmailMessage) => {
+  send: async ({ to, subject, text, replyTo }: EmailMessage) => {
+    const recipient = to ?? toEmail
+
+    // A provider with no default recipient and a message that names none is a
+    // wiring mistake, caught here rather than sent to Lumail to be refused.
+    if (!recipient) throw new EmailError('bad_request', 'Aucun destinataire')
+
     let response: Response
     try {
       response = await fetch(ENDPOINT, {
@@ -75,7 +92,7 @@ const createLumailProvider = ({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          to: toEmail,
+          to: recipient,
           from: formatSender(fromEmail, fromName),
           subject,
           content: text,
@@ -100,3 +117,4 @@ const createLumailProvider = ({
 })
 
 export { createLumailProvider }
+export type { LumailConfig, LumailCredentials }

--- a/apps/frontend/src/lib/email/payload.test.ts
+++ b/apps/frontend/src/lib/email/payload.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createPayloadEmailAdapter, resolvePayloadEmailAdapter } from './payload'
+import { EmailError } from './provider'
+
+import type { EmailMessage, EmailProvider } from './provider'
+import type { Payload } from 'payload'
+
+const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
+
+const CREDENTIALS = {
+  LUMAIL_API_TOKEN: 'lum_token',
+  LUMAIL_FROM_EMAIL: 'contact@domaine.fr',
+}
+
+/** Records what the transport was asked to send, without reaching the network. */
+const stubSender = () => {
+  const send = vi.fn<(message: EmailMessage) => Promise<void>>(() => Promise.resolve())
+  const provider: EmailProvider = { id: 'lumail', send }
+
+  return { send, sender: { provider, fromEmail: 'contact@domaine.fr', fromName: 'Portfolio' } }
+}
+
+/** Payload passes itself to the adapter factory; nothing here reads it. */
+const initialize = (adapter: ReturnType<typeof createPayloadEmailAdapter>) =>
+  adapter({ payload: {} as Payload })
+
+describe('createPayloadEmailAdapter', () => {
+  it('annonce le fournisseur et son expéditeur par défaut', () => {
+    const { sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter(sender))
+
+    expect(adapter.name).toBe('lumail')
+    expect(adapter.defaultFromAddress).toBe('contact@domaine.fr')
+    expect(adapter.defaultFromName).toBe('Portfolio')
+  })
+
+  it('retombe sur l’adresse quand aucun nom d’expéditeur n’est configuré', () => {
+    const { sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter({ ...sender, fromName: undefined }))
+
+    expect(adapter.defaultFromName).toBe('contact@domaine.fr')
+  })
+
+  it('transmet le destinataire de Payload au transport', async () => {
+    const { send, sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter(sender))
+
+    await adapter.sendEmail({ to: 'admin@domaine.fr', subject: 'Sujet', html: 'Corps' })
+
+    expect(send).toHaveBeenCalledWith({
+      to: 'admin@domaine.fr',
+      subject: 'Sujet',
+      text: 'Corps',
+    })
+  })
+
+  it('préfère le corps texte quand Payload en fournit un', async () => {
+    const { send, sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter(sender))
+
+    await adapter.sendEmail({
+      to: 'admin@domaine.fr',
+      subject: 'Sujet',
+      html: 'HTML',
+      text: 'Texte',
+    })
+
+    expect(send.mock.calls[0]?.[0].text).toBe('Texte')
+  })
+
+  /**
+   * A reset link is addressed to one account. Nodemailer's type allows a list and
+   * an object form, and picking one entry out of them would mean mailing a link
+   * to an address nobody asked about.
+   */
+  it('refuse un destinataire qui n’est pas une adresse simple', async () => {
+    const { send, sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter(sender))
+
+    await expect(
+      adapter.sendEmail({ to: ['un@example.com', 'deux@example.com'], subject: 'Sujet', html: 'x' })
+    ).rejects.toBeInstanceOf(EmailError)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('refuse un message sans sujet ni corps', async () => {
+    const { sender } = stubSender()
+    const adapter = initialize(createPayloadEmailAdapter(sender))
+
+    await expect(adapter.sendEmail({ to: 'admin@domaine.fr', html: 'x' })).rejects.toBeInstanceOf(
+      EmailError
+    )
+    await expect(
+      adapter.sendEmail({ to: 'admin@domaine.fr', subject: 'Sujet' })
+    ).rejects.toBeInstanceOf(EmailError)
+  })
+})
+
+/**
+ * Recovery is wired only when the environment can send. An admin deployed before
+ * its sending domain exists must still boot — Payload reports email as
+ * unconfigured, which is the truth, instead of accepting a reset it cannot deliver.
+ */
+describe('resolvePayloadEmailAdapter', () => {
+  it('ne renvoie rien quand aucun expéditeur n’est configuré', () => {
+    expect(resolvePayloadEmailAdapter(env({}))).toBeUndefined()
+  })
+
+  it('n’exige pas le destinataire du formulaire de contact', () => {
+    expect(resolvePayloadEmailAdapter(env(CREDENTIALS))).toBeTypeOf('function')
+  })
+})

--- a/apps/frontend/src/lib/email/payload.ts
+++ b/apps/frontend/src/lib/email/payload.ts
@@ -1,0 +1,89 @@
+import { EmailError } from './provider'
+
+import { resolveEmailSender } from './index'
+
+import type { EmailSender } from './index'
+import type { EmailAdapter, SendEmailOptions } from 'payload'
+
+/**
+ * Bridges Payload's email interface onto the portfolio's own sender.
+ *
+ * Payload sends exactly one kind of message today — the password reset link —
+ * and it has no transport of its own: without an adapter, `forgot-password`
+ * reports success and delivers nothing. Rather than adding a second vendor for
+ * that one message, this maps Payload's call onto the Lumail sender the contact
+ * form already uses.
+ *
+ * Payload hands the body over as `html` because that is what its API is named,
+ * but the transport posts markdown. The template in `users.ts` therefore writes
+ * markdown into that field, which is why nothing here parses or escapes HTML:
+ * the body is passed through as the text it already is.
+ */
+
+/**
+ * Reduces Payload's recipient to the single address the transport accepts.
+ *
+ * Nodemailer's type allows an array and an object form, neither of which Payload
+ * itself produces for a password reset. They are rejected rather than guessed at:
+ * silently mailing the first entry of a list would send a reset link to the wrong
+ * account.
+ */
+const readRecipient = (to: SendEmailOptions['to']): string => {
+  if (typeof to === 'string' && to.trim()) return to.trim()
+
+  throw new EmailError('bad_request', `Destinataire inattendu : ${JSON.stringify(to)}`)
+}
+
+/** Payload types the subject as optional; a mail without one is still a mistake. */
+const readSubject = (subject: SendEmailOptions['subject']): string => {
+  if (typeof subject === 'string' && subject.trim()) return subject.trim()
+
+  throw new EmailError('bad_request', 'Sujet manquant')
+}
+
+/**
+ * Reads the body out of whichever field carried it.
+ *
+ * `text` first because it needs no interpretation. `html` is the field Payload
+ * fills, and the templates that feed it write markdown — see the module note.
+ */
+const readBody = ({ text, html }: SendEmailOptions): string => {
+  if (typeof text === 'string' && text.trim()) return text
+  if (typeof html === 'string' && html.trim()) return html
+
+  throw new EmailError('bad_request', 'Corps de message vide')
+}
+
+/** Wraps a resolved sender into the adapter shape Payload initializes. */
+const createPayloadEmailAdapter =
+  ({ provider, fromEmail, fromName }: EmailSender): EmailAdapter<void> =>
+  () => ({
+    name: provider.id,
+    defaultFromAddress: fromEmail,
+    defaultFromName: fromName ?? fromEmail,
+    sendEmail: async (message) => {
+      await provider.send({
+        to: readRecipient(message.to),
+        subject: readSubject(message.subject),
+        text: readBody(message),
+      })
+    },
+  })
+
+/**
+ * The adapter for the current environment, or `undefined` when none is possible.
+ *
+ * `undefined` is what `buildConfig` expects for "no transport": Payload then logs
+ * that email is not configured instead of failing to boot. That is the right
+ * outcome for a deployment whose sending domain is not verified yet — the admin
+ * still works, only recovery by email is unavailable.
+ */
+const resolvePayloadEmailAdapter = (
+  env: NodeJS.ProcessEnv = process.env
+): EmailAdapter<void> | undefined => {
+  const sender = resolveEmailSender(env)
+
+  return sender ? createPayloadEmailAdapter(sender) : undefined
+}
+
+export { createPayloadEmailAdapter, resolvePayloadEmailAdapter }

--- a/apps/frontend/src/lib/email/provider.ts
+++ b/apps/frontend/src/lib/email/provider.ts
@@ -2,13 +2,21 @@
  * Vendor-agnostic contract for sending one transactional email.
  *
  * The portfolio sends a handful of messages triggered one at a time — a contact
- * form entry today, an account recovery mail tomorrow. Nothing here models
+ * form entry, an account recovery mail. Nothing here models
  * campaigns, lists or templates: that is the vendor's own domain, and pulling it
  * into this interface would tie the callers to whoever is behind it.
  */
 
 /** What a caller hands over. `replyTo` is what makes an answer one click away. */
 interface EmailMessage {
+  /**
+   * Recipient, when the caller knows it better than the provider does.
+   *
+   * The contact form always writes to the same inbox, so its provider carries
+   * the address and callers omit it. Account recovery is the opposite: the
+   * address is the account being recovered, and only the caller has it.
+   */
+  to?: string
   subject: string
   /** Plain text. Callers build it; no provider-specific templating is involved. */
   text: string

--- a/apps/frontend/src/lib/require-env.test.ts
+++ b/apps/frontend/src/lib/require-env.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { requireEnv } from './require-env'
+
+const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
+
+/**
+ * The whole point of this helper is the failure path: it exists because
+ * `?? ''` let a missing secret through. What matters is that nothing empty ever
+ * comes back, and that the message names the variable so the fix is obvious.
+ */
+describe('requireEnv', () => {
+  it('renvoie la valeur quand elle est présente', () => {
+    expect(requireEnv('PAYLOAD_SECRET', env({ PAYLOAD_SECRET: 'un-secret' }))).toBe('un-secret')
+  })
+
+  it('supprime les espaces autour de la valeur', () => {
+    expect(requireEnv('PAYLOAD_SECRET', env({ PAYLOAD_SECRET: '  un-secret  ' }))).toBe('un-secret')
+  })
+
+  it('échoue quand la variable est absente', () => {
+    expect(() => requireEnv('PAYLOAD_SECRET', env({}))).toThrow(/PAYLOAD_SECRET/)
+  })
+
+  it('traite une valeur vide comme absente', () => {
+    expect(() => requireEnv('DATABASE_URI', env({ DATABASE_URI: '' }))).toThrow(/DATABASE_URI/)
+  })
+
+  it('traite une valeur blanche comme absente', () => {
+    expect(() => requireEnv('DATABASE_URI', env({ DATABASE_URI: '   ' }))).toThrow(/DATABASE_URI/)
+  })
+})

--- a/apps/frontend/src/lib/require-env.ts
+++ b/apps/frontend/src/lib/require-env.ts
@@ -1,0 +1,27 @@
+/**
+ * Reads an environment variable the application cannot run without.
+ *
+ * The alternative this replaces — `process.env.X ?? ''` — is worse than a crash.
+ * Payload accepts an empty secret and boots: session cookies and password reset
+ * tokens are then signed with a value an attacker does not even have to steal.
+ * An empty connection string fails later, far from its cause, as a driver error
+ * that names nothing.
+ *
+ * Both are configuration mistakes, and a configuration mistake belongs at load
+ * time, in a message that names the variable. A blank value counts as missing —
+ * `PAYLOAD_SECRET=""` sitting in a `.env` copied from the example is the exact
+ * case this catches.
+ */
+const requireEnv = (name: string, env: NodeJS.ProcessEnv = process.env): string => {
+  const value = env[name]?.trim()
+
+  if (!value) {
+    throw new Error(
+      `Missing environment variable ${name}. See .env.example: the application cannot start without it.`
+    )
+  }
+
+  return value
+}
+
+export { requireEnv }

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -24,6 +24,9 @@
   `/mentions-legales` alimentées depuis la base et prérendues.
 - Cache serveur centralisé dans `src/lib/content-cache.ts`, invalidé à la
   publication par les hooks Payload. Plus aucun `revalidate` dans les pages.
+- Administration Payload durcie (issue #4) : `PAYLOAD_SECRET` et `DATABASE_URI`
+  exigés au chargement, politique de verrouillage explicite sur `users`, et
+  réinitialisation du mot de passe branchée sur le transport Lumail existant.
 - Code hérité de l'ère Express retiré : `lib/api.ts`, `lib/query-client.ts`,
   `providers.tsx`, `data/portfolio.ts`, pages `/liens` et `/demo`. React Query,
   Axios et quatre autres dépendances désinstallées.
@@ -77,6 +80,19 @@
   (`src/lib/open-graph-hook.ts`), paramétré par les noms de champs.
 - Toute URL est canonicalisée avant enregistrement (`src/lib/canonical-url.ts`),
   sinon l'index unique sur `url` laisserait passer des doublons.
+- **Aucune variable d'environnement critique ne prend de valeur de repli.**
+  `process.env.X ?? ''` laissait Payload démarrer avec un secret vide, donc des
+  cookies de session et des jetons de réinitialisation signés avec une valeur
+  devinable. `src/lib/require-env.ts` échoue au chargement en nommant la
+  variable ; une valeur blanche compte comme absente.
+- Payload n'a pas de transport email : sans adaptateur, `forgot-password`
+  répond « envoyé » et ne délivre rien. `src/lib/email/payload.ts` branche
+  l'expéditeur Lumail déjà utilisé par le formulaire de contact. Le corps part
+  en markdown, donc le gabarit de `src/cms/emails/reset-password.ts` écrit du
+  markdown dans le champ que Payload nomme `html`.
+- `resolveEmailSender` (identifiants seuls) et `resolveEmailProvider`
+  (identifiants + `CONTACT_TO_EMAIL`) sont distincts : la récupération de compte
+  écrit au compte concerné, le formulaire à une boîte fixe.
 - Prettier et ESLint doivent être lancés depuis le workspace
   (`pnpm --filter @portfolio/frontend exec …`), pas depuis la racine.
 - Un écran `500` sur toutes les routes `/api/*` et `/admin` après plusieurs


### PR DESCRIPTION
## Summary

Closes the three remaining gaps on the admin security scope (#4), all cases where a missing piece stayed silent instead of failing.

- **No fallback on critical env vars.** `payload.config.ts` read `process.env.PAYLOAD_SECRET ?? ''`, so a deployment missing the variable booted with an *empty signing secret* — session cookies and password-reset tokens signed with a value an attacker does not even have to steal. `DATABASE_URI` had the same fallback and failed later as a driver error naming nothing. Both now go through `src/lib/require-env.ts`, which throws at config load and names the variable; a blank value counts as missing.
- **Explicit lockout policy.** `Users` left the brute-force ceiling to the framework default. The values are unchanged (5 attempts, 10 min) but now written on the collection and asserted by a test, so an upstream change cannot move them unnoticed.
- **Working password recovery.** Payload had no email transport, so `forgot-password` reported success and delivered nothing. Rather than add a second vendor, `src/lib/email/payload.ts` maps Payload's email adapter onto the existing Lumail sender. The resolvers split accordingly — the contact form needs a fixed inbox, recovery writes to the account being recovered — so `resolveEmailSender` asks only for credentials and `EmailMessage` carries an optional `to`. The reset template (`src/cms/emails/reset-password.ts`) is replaced because the transport posts markdown; the link is built from the request origin so it works behind a proxy.
- Without Lumail credentials, `email` stays undefined: the admin boots and reports recovery as unavailable, which is the truth.

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Unit tests pass (`147 passed`, 22 new across `require-env`, `email/payload`, `emails/reset-password`, `collections/users`)
- [x] Fail-fast verified: `payload migrate:status` without `PAYLOAD_SECRET` aborts with the named error; with dummy values the config loads and the failure moves to the DB connection
- [ ] End-to-end recovery mail delivery (requires live Lumail credentials + DB — deployment-time check)

## Validation results

```
pnpm test          → 14 files, 147 passed
pnpm lint          → clean
pnpm type-check    → clean
pnpm format:check  → clean
```

`src/payload-types.ts` was left untouched (the CLI reformats it wholesale; no schema change here).

Closes #4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgdW78pAu3v1RzvYXSHUJZ)_