### PR TITLE
feat(backend): rate-limit the public assistant to stop quota abuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,14 @@ GROQ_API_KEY=""
 # Laissée vide, la valeur par défaut « groq » s'applique.
 AI_PROVIDER=""
 
+# Sel secret qui anonymise les empreintes du limiteur de débit du chat.
+# Générez-le avec : openssl rand -base64 32
+# Le sel est combiné à la date UTC : la même IP donne une empreinte différente
+# chaque jour et ne peut pas être suivie d'un jour à l'autre. Aucune IP brute
+# n'est jamais enregistrée. Absent, le limiteur reste désactivé (une empreinte
+# non salée serait réversible), donc à renseigner avant la mise en ligne.
+CHAT_FINGERPRINT_SALT=""
+
 # --- Email transactionnel (Lumail) ---
 # Jeton d'API Lumail, utilisé par le formulaire de contact.
 # Générez-le depuis votre organisation Lumail (Settings > API tokens).

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -21,6 +21,10 @@ GROQ_API_KEY=""
 # Fournisseur d'IA. Seul « groq » est implémenté ; vide = « groq ».
 AI_PROVIDER=""
 
+# Sel secret du limiteur de débit du chat (empreintes IP anonymisées).
+# Voir le .env.example racine pour le détail. Absent = limiteur désactivé.
+CHAT_FINGERPRINT_SALT=""
+
 # Email transactionnel (Lumail) — voir le .env.example racine pour le détail.
 LUMAIL_API_TOKEN=""
 LUMAIL_FROM_EMAIL=""

--- a/apps/frontend/src/app/(site)/api/chat/route.ts
+++ b/apps/frontend/src/app/(site)/api/chat/route.ts
@@ -1,6 +1,9 @@
+import { headers } from 'next/headers'
 import { z } from 'zod'
 
 import { ProviderError, resolveProvider } from '@/lib/ai'
+import { computeFingerprint } from '@/lib/ai/client-fingerprint'
+import { checkRateLimit } from '@/lib/ai/rate-limit'
 import { buildContext, getAssistantConfig } from '@/lib/assistant-context'
 
 import type { ChatMessage } from '@/lib/ai'
@@ -54,6 +57,16 @@ const streamHeaders = {
 } as const
 
 /**
+ * Shown when a caller has spent their allowance.
+ *
+ * It reads as the assistant's own reply and sends the visitor to the contact
+ * page, so a real person who happened to hit the ceiling still has a way through
+ * rather than a dead error.
+ */
+const RATE_LIMITED_MESSAGE =
+  'Vous avez posé beaucoup de questions d’affilée. Laissez souffler l’assistant une minute, ou écrivez-moi directement depuis la page /contact.'
+
+/**
  * Answers with the editable fallback and HTTP 200.
  *
  * 200 rather than 503 because this *is* the answer as far as the visitor is
@@ -74,6 +87,19 @@ export async function POST(request: Request): Promise<Response> {
   const parsed = requestSchema.safeParse(payload)
   if (!parsed.success) {
     return Response.json({ error: 'Question invalide' }, { status: 400 })
+  }
+
+  // Throttle before touching the provider: a refused caller must cost no token
+  // and reach no context build. The fingerprint is anonymous and per-day; when
+  // no salt is configured it is null, and the limiter stays off rather than
+  // bucketing everyone together — see computeFingerprint.
+  const fingerprint = computeFingerprint(await headers())
+  if (fingerprint) {
+    const verdict = checkRateLimit(fingerprint)
+    if (!verdict.allowed) {
+      console.warn(`[assistant] rate-limited: ${verdict.reason}`)
+      return new Response(RATE_LIMITED_MESSAGE, { status: 429, headers: streamHeaders })
+    }
   }
 
   const settings = await getAssistantConfig()

--- a/apps/frontend/src/hooks/use-assistant.ts
+++ b/apps/frontend/src/hooks/use-assistant.ts
@@ -67,6 +67,16 @@ const useAssistant = (): UseAssistantResult => {
           signal: controller.signal,
         })
 
+        // A spent allowance comes back as 429 with a plain-text notice. It is
+        // content, not a failure to report: shown as the assistant's reply, it
+        // keeps the conversation coherent and points the visitor to /contact.
+        if (response.status === 429) {
+          const notice = await response.text()
+          setTurns((current) => [...current, { role: 'assistant', content: notice }])
+          setStreaming('')
+          return
+        }
+
         if (!response.ok || !response.body) {
           setError(NETWORK_ERROR)
           return

--- a/apps/frontend/src/lib/ai/client-fingerprint.test.ts
+++ b/apps/frontend/src/lib/ai/client-fingerprint.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeFingerprint } from './client-fingerprint'
+
+const env = (vars: Record<string, string>): NodeJS.ProcessEnv => ({ NODE_ENV: 'test', ...vars })
+
+const SALT = env({ CHAT_FINGERPRINT_SALT: 'un-sel-secret' })
+
+const withIp = (ip: string): Headers => new Headers({ 'x-forwarded-for': ip })
+
+// Two instants on different UTC days.
+const DAY_1 = Date.parse('2026-08-24T12:00:00Z')
+const DAY_2 = Date.parse('2026-08-25T12:00:00Z')
+
+describe('computeFingerprint', () => {
+  it('produit une empreinte stable pour une même IP le même jour', () => {
+    const a = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+    const b = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+
+    expect(a).toBe(b)
+  })
+
+  it('distingue deux adresses différentes', () => {
+    const a = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+    const b = computeFingerprint(withIp('203.0.113.8'), SALT, DAY_1)
+
+    expect(a).not.toBe(b)
+  })
+
+  it('change l’empreinte d’un jour à l’autre pour la même IP', () => {
+    const day1 = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+    const day2 = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_2)
+
+    expect(day1).not.toBe(day2)
+  })
+
+  it('dépend du sel : un sel différent donne une empreinte différente', () => {
+    const a = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+    const b = computeFingerprint(
+      withIp('203.0.113.7'),
+      env({ CHAT_FINGERPRINT_SALT: 'autre-sel' }),
+      DAY_1
+    )
+
+    expect(a).not.toBe(b)
+  })
+
+  it('ne contient jamais l’adresse en clair', () => {
+    const fingerprint = computeFingerprint(withIp('203.0.113.7'), SALT, DAY_1)
+
+    expect(fingerprint).not.toContain('203.0.113.7')
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('prend la première entrée de x-forwarded-for', () => {
+    const chained = new Headers({ 'x-forwarded-for': '203.0.113.7, 10.0.0.1, 10.0.0.2' })
+    const single = withIp('203.0.113.7')
+
+    expect(computeFingerprint(chained, SALT, DAY_1)).toBe(computeFingerprint(single, SALT, DAY_1))
+  })
+
+  it('retombe sur x-real-ip quand x-forwarded-for est absent', () => {
+    const real = new Headers({ 'x-real-ip': '203.0.113.7' })
+
+    expect(computeFingerprint(real, SALT, DAY_1)).toBeTypeOf('string')
+  })
+
+  it('regroupe les appelants non identifiés sous le même seau', () => {
+    const a = computeFingerprint(new Headers(), SALT, DAY_1)
+    const b = computeFingerprint(new Headers(), SALT, DAY_1)
+
+    expect(a).toBe(b)
+  })
+
+  it('reste null sans sel : impossible d’anonymiser, donc pas d’empreinte', () => {
+    expect(computeFingerprint(withIp('203.0.113.7'), env({}), DAY_1)).toBeNull()
+    expect(
+      computeFingerprint(withIp('203.0.113.7'), env({ CHAT_FINGERPRINT_SALT: '  ' }), DAY_1)
+    ).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/ai/client-fingerprint.ts
+++ b/apps/frontend/src/lib/ai/client-fingerprint.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Turns a request into an anonymous, per-day caller fingerprint.
+ *
+ * The rate limiter needs to tell callers apart without ever learning who they
+ * are. A bare hash of an IPv4 address is not anonymous — the whole 32-bit space
+ * hashes in minutes, so the digest is trivially reversible. Two things prevent
+ * that here: a secret salt held only in the environment, and the UTC date folded
+ * into the salt so the same address yields a different fingerprint every day and
+ * cannot be followed across them.
+ *
+ * The raw address is never returned, logged or stored. Only the digest leaves
+ * this module.
+ */
+
+/**
+ * Reads the caller's address from the proxy header.
+ *
+ * `x-forwarded-for` is set by the reverse proxy in front of the app and lists
+ * the chain client, proxy, …; the first entry is the original caller. It is
+ * spoofable when the app is reached directly, which is why the deployment must
+ * put the app behind a proxy that overwrites this header — see issue #10. Until
+ * then an unidentified caller shares the `unknown` bucket rather than escaping
+ * the limit.
+ */
+const readClientAddress = (headers: Headers): string => {
+  const forwarded = headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  if (forwarded) return forwarded
+
+  // Some proxies use this instead; kept as a fallback, never trusted alone.
+  const real = headers.get('x-real-ip')?.trim()
+  return real && real !== '' ? real : 'unknown'
+}
+
+/** The salt in effect today: the secret combined with the UTC date. */
+const dailySalt = (secret: string, now: number): string => {
+  const day = new Date(now).toISOString().slice(0, 10) // YYYY-MM-DD, UTC.
+  return `${secret}:${day}`
+}
+
+/**
+ * Computes the fingerprint, or `null` when no secret is configured.
+ *
+ * `null` is a deployment state, not a bug: without a salt the digest would be
+ * reversible, so the caller treats an unconfigured fingerprint as "cannot
+ * anonymise, therefore do not limit" rather than storing something weaker. The
+ * limiter degrades to off, exactly as the assistant degrades to its fallback
+ * without an API key.
+ */
+const computeFingerprint = (
+  headers: Headers,
+  env: NodeJS.ProcessEnv = process.env,
+  now: number = Date.now()
+): string | null => {
+  const secret = env.CHAT_FINGERPRINT_SALT?.trim()
+  if (!secret) return null
+
+  const address = readClientAddress(headers)
+
+  return createHash('sha256')
+    .update(`${dailySalt(secret, now)}:${address}`)
+    .digest('hex')
+}
+
+export { computeFingerprint }

--- a/apps/frontend/src/lib/ai/rate-limit.test.ts
+++ b/apps/frontend/src/lib/ai/rate-limit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { checkRateLimit, resetRateLimit } from './rate-limit'
+
+import type { RateLimitConfig } from './rate-limit'
+
+/** Small, legible ceilings so a test can reach each one in a few calls. */
+const CONFIG: RateLimitConfig = {
+  burst: { windowMs: 1_000, max: 3 },
+  window: { windowMs: 10_000, max: 6 },
+  daily: { windowMs: 1_000_000, max: 10 },
+}
+
+const KEY = 'fingerprint-a'
+
+afterEach(() => {
+  resetRateLimit()
+})
+
+/** Sends `count` requests at `now`, returning the last verdict. */
+const spend = (count: number, now: number) => {
+  let last = checkRateLimit(KEY, CONFIG, now)
+  for (let i = 1; i < count; i += 1) last = checkRateLimit(KEY, CONFIG, now)
+  return last
+}
+
+describe('checkRateLimit', () => {
+  it('laisse passer une conversation normale', () => {
+    // Three questions spread over half a minute stay under every ceiling.
+    expect(checkRateLimit(KEY, CONFIG, 0).allowed).toBe(true)
+    expect(checkRateLimit(KEY, CONFIG, 15_000).allowed).toBe(true)
+    expect(checkRateLimit(KEY, CONFIG, 30_000).allowed).toBe(true)
+  })
+
+  it('rejette une rafale au-delà du seuil de burst', () => {
+    expect(spend(3, 0).allowed).toBe(true)
+    const fourth = checkRateLimit(KEY, CONFIG, 0)
+
+    expect(fourth).toEqual({ allowed: false, reason: 'burst' })
+  })
+
+  it('laisse repartir le burst une fois sa fenêtre passée', () => {
+    spend(3, 0)
+    expect(checkRateLimit(KEY, CONFIG, 0).allowed).toBe(false)
+
+    // 1.1s later the burst window has slid past the first three.
+    expect(checkRateLimit(KEY, CONFIG, 1_100).allowed).toBe(true)
+  })
+
+  it('rejette au seuil de la fenêtre, sans déclencher le burst', () => {
+    // Spaced just past the burst window so burst never trips; all still inside
+    // the 10s window. The sixth fills it, the seventh is refused on 'window'.
+    let last = checkRateLimit(KEY, CONFIG, 0)
+    for (let i = 1; i < CONFIG.window.max; i += 1) {
+      last = checkRateLimit(KEY, CONFIG, i * 1_100)
+    }
+    expect(last.allowed).toBe(true)
+
+    expect(checkRateLimit(KEY, CONFIG, CONFIG.window.max * 1_100)).toEqual({
+      allowed: false,
+      reason: 'window',
+    })
+  })
+
+  it('applique le plafond quotidien, sans déclencher les tiers plus courts', () => {
+    // Spaced past the window (10s) so only the daily cap accumulates.
+    const step = CONFIG.window.windowMs + 1_000
+    let last = checkRateLimit(KEY, CONFIG, 0)
+    for (let i = 1; i < CONFIG.daily.max; i += 1) {
+      last = checkRateLimit(KEY, CONFIG, i * step)
+    }
+    expect(last.allowed).toBe(true)
+
+    expect(checkRateLimit(KEY, CONFIG, CONFIG.daily.max * step)).toEqual({
+      allowed: false,
+      reason: 'daily',
+    })
+  })
+
+  it('ne compte pas une requête refusée, pour ne pas allonger le blocage', () => {
+    spend(3, 0)
+    // Two refusals while blocked…
+    checkRateLimit(KEY, CONFIG, 200)
+    checkRateLimit(KEY, CONFIG, 400)
+
+    // …must not delay recovery: the window still clears 1s after the last allowed hit.
+    expect(checkRateLimit(KEY, CONFIG, 1_100).allowed).toBe(true)
+  })
+
+  it('sépare les appelants : l’un bloqué n’affecte pas l’autre', () => {
+    spend(3, 0)
+    expect(checkRateLimit(KEY, CONFIG, 0).allowed).toBe(false)
+
+    expect(checkRateLimit('fingerprint-b', CONFIG, 0).allowed).toBe(true)
+  })
+})

--- a/apps/frontend/src/lib/ai/rate-limit.ts
+++ b/apps/frontend/src/lib/ai/rate-limit.ts
@@ -1,0 +1,109 @@
+/**
+ * In-memory rate limiter for the public assistant.
+ *
+ * The chat concatenates a question into a prompt billed by the token and calls
+ * an external provider on every turn, so an unthrottled endpoint is a way to
+ * drain a quota or run up a bill from a shell loop. This bounds that.
+ *
+ * Three ceilings, checked together, each catching a different shape of abuse:
+ *   - burst  — a handful of requests in a few seconds, the scripted loop
+ *   - window — a steady stream over a minute, the patient scraper
+ *   - daily  — the total one caller may spend in a day
+ *
+ * Counters live in a module-level `Map`, deliberately not in Redis or Postgres:
+ * the site runs a handful of instances at most, and a limiter that forgets a
+ * caller after a redeploy still turns "a thousand requests" into "a few". The
+ * cost of a datastore would exceed what it buys today. The trade-off is explicit
+ * and the limiter sits behind a narrow interface, so swapping in a shared store
+ * later is a one-file change. The provider's own quota remains the real ceiling.
+ */
+
+/** One tier of the limit: at most `max` hits within `windowMs`. */
+interface Tier {
+  windowMs: number
+  max: number
+}
+
+interface RateLimitConfig {
+  burst: Tier
+  window: Tier
+  daily: Tier
+}
+
+/** Why a caller was refused, so the route can log which ceiling bit. */
+type RateLimitReason = 'burst' | 'window' | 'daily'
+
+type RateLimitResult = { allowed: true } | { allowed: false; reason: RateLimitReason }
+
+/**
+ * Default ceilings, sized for a real conversation.
+ *
+ * A person asking follow-up questions sends a message every few seconds at most
+ * and a few dozen in a sitting; these bounds sit well above that and well below
+ * what a script would want. They are the decision, reviewable here rather than
+ * inherited from anywhere.
+ */
+const DEFAULT_CONFIG: RateLimitConfig = {
+  burst: { windowMs: 10_000, max: 5 },
+  window: { windowMs: 60_000, max: 15 },
+  daily: { windowMs: 24 * 60 * 60_000, max: 200 },
+}
+
+/**
+ * Recent hit timestamps per caller, newest last.
+ *
+ * A plain `Map` would grow without bound, so each entry is pruned to the longest
+ * window on every touch and dropped once empty. The map therefore stays as small
+ * as the set of callers active within a day.
+ */
+const hits = new Map<string, number[]>()
+
+/** Count of timestamps within `windowMs` of `now`. */
+const countWithin = (timestamps: number[], windowMs: number, now: number): number =>
+  timestamps.reduce((total, at) => (now - at < windowMs ? total + 1 : total), 0)
+
+/**
+ * Records a hit for the caller and reports whether it is allowed.
+ *
+ * The hit is recorded only when allowed: a refused request must not push the
+ * caller further past the limit, which would extend their lockout every time
+ * they retry. Order matters — burst first, then window, then daily — so the log
+ * names the tightest ceiling the caller actually crossed.
+ */
+const checkRateLimit = (
+  key: string,
+  config: RateLimitConfig = DEFAULT_CONFIG,
+  now: number = Date.now()
+): RateLimitResult => {
+  const longestWindow = Math.max(
+    config.burst.windowMs,
+    config.window.windowMs,
+    config.daily.windowMs
+  )
+
+  const timestamps = (hits.get(key) ?? []).filter((at) => now - at < longestWindow)
+
+  for (const [reason, tier] of [
+    ['burst', config.burst],
+    ['window', config.window],
+    ['daily', config.daily],
+  ] as const) {
+    if (countWithin(timestamps, tier.windowMs, now) >= tier.max) {
+      // Keep the pruned list so the entry does not regrow with stale timestamps.
+      hits.set(key, timestamps)
+      return { allowed: false, reason }
+    }
+  }
+
+  timestamps.push(now)
+  hits.set(key, timestamps)
+  return { allowed: true }
+}
+
+/** Clears all recorded hits. Test-only; production state lives for the process. */
+const resetRateLimit = (): void => {
+  hits.clear()
+}
+
+export { checkRateLimit, resetRateLimit, DEFAULT_CONFIG }
+export type { RateLimitConfig, RateLimitReason, RateLimitResult }

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -24,6 +24,12 @@
   `/mentions-legales` alimentées depuis la base et prérendues.
 - Cache serveur centralisé dans `src/lib/content-cache.ts`, invalidé à la
   publication par les hooks Payload. Plus aucun `revalidate` dans les pages.
+- Chat protégé contre les abus (issue #10, 1er lot) : limiteur de débit à trois
+  paliers (rafale / minute / jour) dans `src/lib/ai/rate-limit.ts`, empreinte IP
+  salée et rotée quotidiennement dans `src/lib/ai/client-fingerprint.ts`. Le 429
+  part avant `resolveProvider`/`buildContext`, donc sans consommer de quota Groq,
+  et renvoie vers `/contact`. Rétention des conversations, feedback et page de
+  confidentialité restent à faire (2e lot de #10).
 - Code hérité de l'ère Express retiré : `lib/api.ts`, `lib/query-client.ts`,
   `providers.tsx`, `data/portfolio.ts`, pages `/liens` et `/demo`. React Query,
   Axios et quatre autres dépendances désinstallées.
@@ -77,6 +83,15 @@
   (`src/lib/open-graph-hook.ts`), paramétré par les noms de champs.
 - Toute URL est canonicalisée avant enregistrement (`src/lib/canonical-url.ts`),
   sinon l'index unique sur `url` laisserait passer des doublons.
+- Limiteur du chat : compteurs en mémoire (`Map` de module), fenêtre glissante,
+  pas de datastore — assumé, l'app tourne en une poignée d'instances et le
+  limiteur vit derrière une interface étroite (bascule Redis = un seul fichier).
+  Les compteurs sont remis à zéro au redéploiement ; le quota du fournisseur
+  reste le vrai plafond. L'empreinte combine `CHAT_FINGERPRINT_SALT` (secret
+  d'environnement) et la date UTC : rotation quotidienne sans manipuler la
+  variable. Sans sel, `computeFingerprint` renvoie `null` et le limiteur reste
+  éteint plutôt que de hacher une valeur réversible ou de regrouper tout le
+  monde. Aucune IP brute n'est jamais stockée ni journalisée.
 - Prettier et ESLint doivent être lancés depuis le workspace
   (`pnpm --filter @portfolio/frontend exec …`), pas depuis la racine.
 - Un écran `500` sur toutes les routes `/api/*` et `/admin` après plusieurs


### PR DESCRIPTION
First batch of #10: the anti-abuse layer, which closes the one remotely-exploitable risk found in the security audit — the chat endpoint was fully public with no throttle, so a shell loop could drain the Groq quota or run up the bill and hold a worker for the streaming duration on every request.

## Summary

- **Three-tier sliding-window limiter** (`src/lib/ai/rate-limit.ts`): burst (a scripted loop), window (a steady scraper) and daily (the total one caller may spend), checked together. Counters live in a module-level `Map` behind a narrow interface — deliberately no datastore: the site runs a handful of instances, the provider quota is the real ceiling, and a limiter that forgets a caller on redeploy still turns a thousand requests into a few. Swapping in a shared store later is a one-file change.
- **Anonymous per-day fingerprint** (`src/lib/ai/client-fingerprint.ts`): a bare hash of an IPv4 address is reversible in minutes, so the digest folds in a secret salt (`CHAT_FINGERPRINT_SALT`) and the UTC date — the same address yields a different fingerprint every day and cannot be followed across them. No raw address is ever stored or logged. Without a salt the fingerprint is `null` and the limiter stays off rather than hashing something reversible.
- **429 before the provider**: the throttle runs before `resolveProvider` and `buildContext`, so a refused caller costs no Groq token and no context build. The plain-text body sends the visitor to `/contact`, and the client renders it as the assistant's reply, not a network error.

## Acceptance criteria covered (from #10)

- [x] No raw IP is ever stored (`x-forwarded-for` is hashed, never persisted)
- [x] The fingerprint uses a secret salt and rotates daily
- [x] Limits block abuse without breaking a normal conversation (ceilings sit well above a real exchange)
- [x] A burst is rejected before reaching the provider
- [x] A reached limit points to the contact page
- [x] A reached limit returns 429 without consuming Groq quota
- [x] The limit stays applicable behind the VPS proxy (keyed off the proxy's forwarded address)

## Deferred to a second batch (rest of #10)

Conversation retention + automatic 30-day purge, useful/not-useful feedback, the retention notice under the chat input, and the privacy-policy page. These need a new Payload collection and a scheduled purge, so they are kept separate from this focused security fix.

**This PR is deliberately `Refs #10`, not `Closes #10`:** #10 stays open to track the second batch above.

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Unit tests pass (`131 passed`, 16 new across `rate-limit` and `client-fingerprint` — burst/window/daily boundaries, refusals not extending lockout, per-caller isolation, salt rotation, no raw IP in the digest, limiter-off without a salt)
- [x] `pnpm format:check` clean

## Validation results

```
pnpm test          → 131 passed
pnpm lint          → clean
pnpm type-check    → clean
pnpm format:check  → clean
```

The limiter lives in the route, not in the provider, so it is unaffected by the Vercel AI SDK migration (#39).

Refs #10