### PR TITLE
feat(devops): add security headers, harden SSRF guard against redirects

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -7,8 +7,65 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })
 
+/**
+ * Content Security Policy, applied to every route.
+ *
+ * `script-src`/`style-src` keep `'unsafe-inline'` because Next injects inline
+ * bootstrap scripts and Payload's admin ships inline styles, and neither carries
+ * a nonce without a middleware that rewrites every response. `'unsafe-eval'` is
+ * kept for the same reason on the admin side. Tightening these to a nonce-based
+ * policy is a deliberate follow-up (#66); what this policy buys today is the rest
+ * of the surface:
+ *   - `frame-ancestors 'none'` — the admin login can no longer be framed
+ *     (clickjacking), the concrete risk the audit named.
+ *   - `object-src 'none'`, `base-uri 'self'`, `form-action 'self'` — no plugin
+ *     injection, no base-tag hijack, no form posting to a foreign origin.
+ *   - `img-src` allows any `https:` host because bookmark previews, favicons and
+ *     project covers are rendered `unoptimized`, i.e. straight from the source.
+ *     Everything else is pinned to the origin.
+ *
+ * Groq and Lumail are called server-side, so they never appear in `connect-src`;
+ * Vercel Analytics and Speed Insights load and beacon same-origin; `next/font`
+ * self-hosts Inter at build time — so no third-party host is needed anywhere.
+ */
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "worker-src 'self' blob:",
+  "frame-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ')
+
+/**
+ * Security headers for every response.
+ *
+ * These are pure hardening: none of them changes what the app renders, so they
+ * are safe to apply globally. `X-Frame-Options` duplicates `frame-ancestors` for
+ * browsers that predate CSP Level 2.
+ */
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+  },
+  // Only honoured over HTTPS, inert on plain HTTP: safe to send everywhere.
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains' },
+]
+
 const nextConfig: NextConfig = {
   output: process.env.DOCKER_BUILD === 'true' ? 'standalone' : undefined,
+  headers: () => Promise.resolve([{ source: '/:path*', headers: securityHeaders }]),
 }
 
 export default withPayload(withBundleAnalyzer(nextConfig))

--- a/apps/frontend/src/cms/collections/ai-knowledge.ts
+++ b/apps/frontend/src/cms/collections/ai-knowledge.ts
@@ -16,6 +16,12 @@ const { afterChange, afterDelete } = revalidateCollection(CONTENT_TAGS.aiKnowled
  *
  * `published` gates an entry without deleting it: a half-written answer stays in
  * `/admin` while remaining invisible to the model.
+ *
+ * Security note: `read` being admin-only protects the API, not the content. Every
+ * published entry is fed to the assistant, and a visitor can coax a model into
+ * repeating its context (prompt injection). So treat this collection as readable
+ * by any visitor through the chat: put here only what Adem would say out loud,
+ * never a private note, an address, or anything that must not leave the site.
  */
 const AIKnowledge: CollectionConfig = {
   slug: 'ai-knowledge',

--- a/apps/frontend/src/cms/open-graph.test.ts
+++ b/apps/frontend/src/cms/open-graph.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { resolveSafeUrl } from './open-graph'
+import { fetchOpenGraphMetadata, resolveSafeUrl } from './open-graph'
 
 /**
  * These tests protect a security guard: `resolveSafeUrl` is what keeps a URL
@@ -56,5 +56,68 @@ describe('resolveSafeUrl', () => {
 
   it('refuse un hôte qui ne résout pas', async () => {
     expect(await resolveSafeUrl('https://hote-inexistant.invalid/')).toBeNull()
+  })
+})
+
+describe('fetchOpenGraphMetadata — suivi de redirection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const redirect = (location: string): Response =>
+    new Response(null, { status: 302, headers: { location } })
+
+  const htmlPage = (html: string): Response =>
+    new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+  /** Serves the queued responses in order, one per fetch call. */
+  const stubFetchQueue = (responses: Response[]) => {
+    let call = 0
+    const spy = vi.fn(() => Promise.resolve(responses[call++] ?? htmlPage('')))
+    vi.stubGlobal('fetch', spy)
+    return spy
+  }
+
+  it('lit les balises quand la cible répond directement', async () => {
+    stubFetchQueue([htmlPage('<meta property="og:title" content="Titre" />')])
+
+    const meta = await fetchOpenGraphMetadata('https://example.com/')
+    expect(meta.title).toBe('Titre')
+  })
+
+  it('suit une redirection vers une cible publique', async () => {
+    const spy = stubFetchQueue([
+      redirect('https://example.com/final'),
+      htmlPage('<meta property="og:title" content="Après redirection" />'),
+    ])
+
+    const meta = await fetchOpenGraphMetadata('https://example.com/')
+    expect(meta.title).toBe('Après redirection')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  /**
+   * The core of the SSRF fix: a public URL that redirects to the cloud metadata
+   * endpoint must not reach it. The second hop is refused by the private-range
+   * guard, so the internal address is never fetched.
+   */
+  it('refuse une redirection vers une adresse interne, sans l’atteindre', async () => {
+    const spy = stubFetchQueue([redirect('http://169.254.169.254/latest/meta-data/')])
+
+    const meta = await fetchOpenGraphMetadata('https://example.com/')
+    expect(meta).toEqual({ title: null, description: null, imageUrl: null })
+    // Only the first hop was fetched; the internal address never was.
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('abandonne au-delà du nombre maximal de redirections', async () => {
+    const spy = stubFetchQueue(
+      Array.from({ length: 8 }, (_, i) => redirect(`https://example.com/hop-${i}`))
+    )
+
+    const meta = await fetchOpenGraphMetadata('https://example.com/')
+    expect(meta.title).toBeNull()
+    // MAX_REDIRECTS (5) hops plus the initial request, never the eighth.
+    expect(spy).toHaveBeenCalledTimes(6)
   })
 })

--- a/apps/frontend/src/cms/open-graph.ts
+++ b/apps/frontend/src/cms/open-graph.ts
@@ -21,6 +21,18 @@ const FETCH_TIMEOUT_MS = 8_000
 const MAX_BYTES = 512 * 1_024
 
 /**
+ * How many redirects a fetch may follow.
+ *
+ * Redirects are followed by hand rather than by `fetch` so each hop is
+ * re-validated: a public URL that answers `302 Location: http://169.254.169.254/`
+ * would otherwise reach the cloud metadata endpoint, since the browser's own
+ * follow does not re-run the private-range check. A handful of hops covers every
+ * legitimate `http→https` or `www` redirect; beyond that is a loop or an attempt
+ * to wear the limit down.
+ */
+const MAX_REDIRECTS = 5
+
+/**
  * Reserved or private ranges (RFC 1918, loopback, link-local, CGNAT…).
  * A URL resolving to one of them is refused.
  */
@@ -222,6 +234,47 @@ const decodeHtmlEntities = (value: string): string =>
  * Never throws: any error (refused URL, unreachable host, page without tags)
  * turns into `null` fields, leaving the admin free to supply a visual by hand.
  */
+/** A 3xx with a `Location`: the response is a hop, not a page. */
+const isRedirect = (response: Response): boolean =>
+  response.status >= 300 && response.status < 400 && response.headers.has('location')
+
+/**
+ * Fetches `url`, following redirects by hand so every hop is re-validated.
+ *
+ * `redirect: 'manual'` stops `fetch` from following on its own — which it would
+ * do without re-checking the destination against the private-range guard. Each
+ * `Location` is resolved to an absolute URL and passed back through
+ * `resolveSafeUrl`; a hop that points anywhere internal ends the walk with
+ * `null`. Returns the first non-redirect response, or `null` when the chain is
+ * refused, loops past `MAX_REDIRECTS`, or sends a malformed `Location`.
+ */
+const fetchFollowingSafely = async (start: URL, signal: AbortSignal): Promise<Response | null> => {
+  let url = start
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const response = await fetch(url, {
+      signal,
+      redirect: 'manual',
+      headers: {
+        // Some sites only serve Open Graph tags to known agents.
+        'User-Agent': 'Mozilla/5.0 (compatible; PortfolioPreviewBot/1.0)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    })
+
+    if (!isRedirect(response)) return response
+
+    const location = response.headers.get('location')
+    const next = location ? toAbsoluteUrl(location, url.href) : null
+    const safeNext = next ? await resolveSafeUrl(next) : null
+    if (!safeNext) return null
+
+    url = safeNext
+  }
+
+  return null
+}
+
 const fetchOpenGraphMetadata = async (rawUrl: string): Promise<OpenGraphMetadata> => {
   const empty: OpenGraphMetadata = { title: null, description: null, imageUrl: null }
 
@@ -232,17 +285,8 @@ const fetchOpenGraphMetadata = async (rawUrl: string): Promise<OpenGraphMetadata
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
   try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-      headers: {
-        // Some sites only serve Open Graph tags to known agents.
-        'User-Agent': 'Mozilla/5.0 (compatible; PortfolioPreviewBot/1.0)',
-        Accept: 'text/html,application/xhtml+xml',
-      },
-    })
-
-    if (!response.ok) return empty
+    const response = await fetchFollowingSafely(url, controller.signal)
+    if (!response?.ok) return empty
 
     const contentType = response.headers.get('content-type') ?? ''
     if (!contentType.includes('html')) return empty
@@ -254,8 +298,8 @@ const fetchOpenGraphMetadata = async (rawUrl: string): Promise<OpenGraphMetadata
     return {
       title: findMetaContent(html, ['og:title', 'twitter:title']) ?? findTitleTag(html),
       description: findMetaContent(html, ['og:description', 'twitter:description', 'description']),
-      // A relative image is resolved against the page URL.
-      imageUrl: imageUrl ? toAbsoluteUrl(imageUrl, url.href) : null,
+      // A relative image is resolved against the page the redirects landed on.
+      imageUrl: imageUrl ? toAbsoluteUrl(imageUrl, response.url || url.href) : null,
     }
   } catch {
     return empty

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -27,6 +27,13 @@
 - Administration Payload durcie (issue #4) : `PAYLOAD_SECRET` et `DATABASE_URI`
   exigés au chargement, politique de verrouillage explicite sur `users`, et
   réinitialisation du mot de passe branchée sur le transport Lumail existant.
+- Surface d'attaque durcie (issue #66, lot indépendant du déploiement) :
+  en-têtes de sécurité + CSP dans `next.config.ts` (CSP volontairement permissive
+  sur script/style, mais `frame-ancestors 'none'`, `object-src`, `base-uri`,
+  `form-action` verrouillés), suivi de redirection revalidé dans le hook Open
+  Graph (plus de bypass SSRF par `302` vers une adresse interne), et note
+  d'injection de prompt sur `ai-knowledge`. Restent liés au proxy/prod : confiance
+  `X-Forwarded-For` (#66.2) et config `cors`/`csrf`/cookies Payload (#66.4).
 - Chat protégé contre les abus (issue #10, 1er lot) : limiteur de débit à trois
   paliers (rafale / minute / jour) dans `src/lib/ai/rate-limit.ts`, empreinte IP
   salée et rotée quotidiennement dans `src/lib/ai/client-fingerprint.ts`. Le 429
@@ -99,6 +106,16 @@
 - `resolveEmailSender` (identifiants seuls) et `resolveEmailProvider`
   (identifiants + `CONTACT_TO_EMAIL`) sont distincts : la récupération de compte
   écrit au compte concerné, le formulaire à une boîte fixe.
+- CSP : `script-src`/`style-src` gardent `'unsafe-inline'` (+`'unsafe-eval'`) car
+  Next injecte des scripts inline et l'admin Payload des styles inline, sans nonce
+  sans middleware. `img-src` autorise `https:` parce que les previews de veille,
+  favicons et covers projets sont rendus `unoptimized` (donc chargés depuis la
+  source). Fonts auto-hébergées (`next/font`), Groq/Lumail côté serveur, Vercel
+  Analytics same-origin : aucun hôte tiers requis. Resserrer `script-src` en
+  politique à nonce est un suivi de #66.
+- Le hook Open Graph suit les redirections à la main (`redirect: 'manual'`,
+  `MAX_REDIRECTS`) et repasse chaque `Location` par `resolveSafeUrl` : `fetch`
+  suivrait sinon une redirection vers une IP interne sans re-vérifier.
 - Limiteur du chat : compteurs en mémoire (`Map` de module), fenêtre glissante,
   pas de datastore — assumé, l'app tourne en une poignée d'instances et le
   limiteur vit derrière une interface étroite (bascule Redis = un seul fichier).


### PR DESCRIPTION
Deployment-independent batch of the security audit (#66) — the three findings that don't depend on the VPS proxy or production-only config.

## Summary

- **Security headers on every response** (`next.config.ts`). A `Content-Security-Policy` plus `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` and HSTS. The admin login can no longer be framed (clickjacking), and `object-src`/`base-uri`/`form-action` are locked down. The CSP keeps `'unsafe-inline'` on `script-src`/`style-src` because Next injects inline bootstrap scripts and Payload's admin ships inline styles with no nonce; `img-src` allows `https:` because bookmark previews, favicons and project covers render `unoptimized`, straight from the source. Groq/Lumail are server-side, Vercel Analytics is same-origin, `next/font` self-hosts Inter — so no third-party host is needed. Tightening `script-src` to a nonce policy is a tracked follow-up.
- **SSRF guard follows redirects by hand** (`src/cms/open-graph.ts`). `fetch` followed redirects on its own without re-checking the destination, so a public URL answering `302 Location: http://169.254.169.254/` reached the cloud-metadata endpoint. Redirects now use `redirect: 'manual'`, each `Location` re-validated through `resolveSafeUrl`, capped at `MAX_REDIRECTS`. New tests assert an internal redirect target is refused **and never fetched**.
- **Prompt-injection note** on the `ai-knowledge` collection: `read` being admin-only protects the API, not the content — every published entry is fed to the assistant and a visitor can coax the model into repeating it. Documented so nothing private is put there.

## Still open in #66 (deployment-tied, deferred)

- `X-Forwarded-For` trust behind the reverse proxy (#66.2) — needs the proxy from #3.
- Payload `cors`/`csrf`/cookie config for production (#66.4).

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Unit tests pass (`167 passed`, 4 new: direct fetch, public redirect followed, internal redirect refused-without-fetch, redirect cap)
- [x] `pnpm format:check` clean
- [ ] **Manual check on the Vercel preview**: confirm `/admin` loads, logs in, and the Lexical editor works under the CSP; confirm bookmark/project preview images still render. The CSP is the one change that could break a runtime the unit tests don't exercise.

## Validation results

```
pnpm test          → 167 passed
pnpm lint          → clean
pnpm type-check    → clean
pnpm format:check  → clean
```

Refs #66

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgdW78pAu3v1RzvYXSHUJZ)_