### PR TITLE
feat(backend): retain chat transcripts, add feedback and a privacy page

### DIFF
--- a/apps/frontend/src/app/(site)/(home)/_components/conversation-section.tsx
+++ b/apps/frontend/src/app/(site)/(home)/_components/conversation-section.tsx
@@ -18,6 +18,7 @@ interface ConversationSectionProps {
   skills: string[]
   availability: HomeAvailability
   projects: HomeProject[]
+  retentionNotice: string
 }
 
 /**
@@ -37,6 +38,7 @@ export function ConversationSection({
   skills,
   availability,
   projects,
+  retentionNotice,
 }: ConversationSectionProps) {
   const chatRef = useRef<HeroChatHandle>(null)
 
@@ -53,6 +55,7 @@ export function ConversationSection({
         projectCount={projectCount}
         skills={skills}
         availability={availability}
+        retentionNotice={retentionNotice}
         chatRef={chatRef}
       />
       <HomeRail onStartChat={startChat} />

--- a/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
+++ b/apps/frontend/src/app/(site)/(home)/_components/hero.tsx
@@ -9,6 +9,8 @@ import {
   Send,
   Sparkles,
   Star,
+  ThumbsDown,
+  ThumbsUp,
 } from 'lucide-react'
 import { AnimatePresence, m } from 'motion/react'
 import Image from 'next/image'
@@ -45,6 +47,7 @@ interface HeroProps {
   projectCount: number
   skills: string[]
   availability: HomeAvailability
+  retentionNotice: string
   chatRef: RefObject<HeroChatHandle | null>
 }
 
@@ -56,13 +59,17 @@ export function Hero({
   projectCount,
   skills,
   availability,
+  retentionNotice,
   chatRef,
 }: HeroProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const threadRef = useRef<HTMLDivElement>(null)
   const [question, setQuestion] = useState('')
-  const { turns, streaming, pending, error, ask } = useAssistant()
+  const { turns, streaming, pending, error, feedback, ask, rate } = useAssistant()
   const started = turns.length > 0
+  // Feedback is offered once the assistant has answered and nothing is streaming:
+  // rating an answer still being written makes no sense.
+  const canRate = turns.some((turn) => turn.role === 'assistant') && !pending && !streaming
   const shownSkills = (skills.length > 0 ? skills : [...skillsContent.fallback]).slice(0, 5)
 
   useEffect(() => {
@@ -262,6 +269,34 @@ export function Hero({
             ) : null}
           </div>
 
+          {canRate ? (
+            <div className="chat-feedback">
+              {feedback ? (
+                <span className="chat-feedback-thanks" role="status">
+                  {chat.feedbackThanks}
+                </span>
+              ) : (
+                <>
+                  <span>{chat.feedbackPrompt}</span>
+                  <button
+                    type="button"
+                    aria-label={chat.feedbackUseful}
+                    onClick={() => rate('useful')}
+                  >
+                    <ThumbsUp size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={chat.feedbackNotUseful}
+                    onClick={() => rate('not_useful')}
+                  >
+                    <ThumbsDown size={14} />
+                  </button>
+                </>
+              )}
+            </div>
+          ) : null}
+
           <AnimatePresence>
             {error ? (
               <m.p
@@ -291,6 +326,10 @@ export function Hero({
               <Send size={15} />
             </button>
           </form>
+
+          <p className="chat-retention">
+            {retentionNotice} <Link href="/confidentialite">{chat.privacyLink}</Link>
+          </p>
         </m.div>
       </aside>
 

--- a/apps/frontend/src/app/(site)/(home)/_content.ts
+++ b/apps/frontend/src/app/(site)/(home)/_content.ts
@@ -21,6 +21,11 @@ export const HOME_CONTENT = {
     inputLabel: 'Posez votre question',
     inputPlaceholder: 'Posez votre question…',
     submitLabel: 'Envoyer',
+    feedbackPrompt: 'Cette réponse vous a-t-elle aidé ?',
+    feedbackUseful: 'Réponse utile',
+    feedbackNotUseful: 'Réponse pas utile',
+    feedbackThanks: 'Merci pour votre retour.',
+    privacyLink: 'En savoir plus',
   },
   profile: {
     heading: 'Profil',

--- a/apps/frontend/src/app/(site)/(home)/_styles.css
+++ b/apps/frontend/src/app/(site)/(home)/_styles.css
@@ -325,6 +325,45 @@
   color: var(--muted);
   font-size: 12px;
 }
+.chat-feedback {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: var(--text-2xs);
+}
+.chat-feedback button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+.chat-feedback button:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.chat-retention {
+  flex: 0 0 auto;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: var(--text-2xs);
+  line-height: 1.5;
+}
+.chat-retention a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
 .chat-form {
   flex: 0 0 auto;
   display: flex;

--- a/apps/frontend/src/app/(site)/(home)/page.tsx
+++ b/apps/frontend/src/app/(site)/(home)/page.tsx
@@ -1,3 +1,4 @@
+import { getAssistantConfig } from '@/lib/assistant-context'
 import { getAvailability, getIdentity, getProfile, listProjects } from '@/lib/site-content'
 
 import { ConversationSection } from './_components/conversation-section'
@@ -10,11 +11,12 @@ const PROJECT_FALLBACK_IMAGES: Record<string, string> = {
 }
 
 async function Home() {
-  const [identity, availability, profile, projects] = await Promise.all([
+  const [identity, availability, profile, projects, assistant] = await Promise.all([
     getIdentity(),
     getAvailability(),
     getProfile(),
     listProjects(),
+    getAssistantConfig(),
   ])
 
   // Without a project flagged as featured, show the first of the sort order
@@ -32,6 +34,7 @@ async function Home() {
         projectCount={projects.length}
         skills={profile.skillGroups.flatMap((group) => group.items).slice(0, 5)}
         availability={{ available: availability.available, label: availability.label }}
+        retentionNotice={assistant.retentionNotice}
         projects={shown.map((project) => ({
           id: project.id,
           url: project.url,

--- a/apps/frontend/src/app/(site)/api/chat/feedback/route.ts
+++ b/apps/frontend/src/app/(site)/api/chat/feedback/route.ts
@@ -1,0 +1,52 @@
+import { headers } from 'next/headers'
+import { z } from 'zod'
+
+import { computeFingerprint } from '@/lib/ai/client-fingerprint'
+import { checkRateLimit } from '@/lib/ai/rate-limit'
+import { setConversationFeedback } from '@/lib/conversation-store'
+
+/**
+ * Records a visitor's useful / not-useful rating on a conversation.
+ *
+ * A separate route from the chat because feedback arrives out of band, after the
+ * answer streamed. It writes a single field on a row that holds no identity, so
+ * the worst a caller can do is set a value on a conversation whose opaque id they
+ * already know — still rate-limited, since a write is a write.
+ */
+
+export const dynamic = 'force-dynamic'
+
+const feedbackSchema = z.object({
+  conversationId: z.uuid(),
+  rating: z.enum(['useful', 'not_useful']),
+})
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return Response.json({ error: 'Corps de requête invalide' }, { status: 400 })
+  }
+
+  const parsed = feedbackSchema.safeParse(payload)
+  if (!parsed.success) {
+    return Response.json({ error: 'Retour invalide' }, { status: 400 })
+  }
+
+  // A write, so it shares the chat's ceiling rather than opening a free lane.
+  const fingerprint = computeFingerprint(await headers())
+  if (fingerprint && !checkRateLimit(fingerprint).allowed) {
+    return Response.json({ error: 'Trop de requêtes' }, { status: 429 })
+  }
+
+  try {
+    const updated = await setConversationFeedback(parsed.data.conversationId, parsed.data.rating)
+    if (!updated) return Response.json({ error: 'Conversation inconnue' }, { status: 404 })
+  } catch (error) {
+    console.error('[assistant] feedback not stored:', error)
+    return Response.json({ error: 'Enregistrement impossible' }, { status: 500 })
+  }
+
+  return new Response(null, { status: 204 })
+}

--- a/apps/frontend/src/app/(site)/api/chat/route.ts
+++ b/apps/frontend/src/app/(site)/api/chat/route.ts
@@ -5,6 +5,7 @@ import { ProviderError, resolveProvider } from '@/lib/ai'
 import { computeFingerprint } from '@/lib/ai/client-fingerprint'
 import { checkRateLimit } from '@/lib/ai/rate-limit'
 import { buildContext, getAssistantConfig } from '@/lib/assistant-context'
+import { recordExchange } from '@/lib/conversation-store'
 
 import type { ChatMessage } from '@/lib/ai'
 
@@ -33,6 +34,12 @@ const MAX_HISTORY_TURNS = 8
 
 const requestSchema = z.object({
   question: z.string().trim().min(1, 'Question vide').max(MAX_QUESTION_LENGTH),
+  /**
+   * Opaque, client-generated id that ties the turns of one conversation together
+   * when they are stored. A UUID and nothing else: it carries no identity, and
+   * validating the shape keeps a caller from writing an arbitrary key.
+   */
+  conversationId: z.uuid().optional(),
   /**
    * Prior turns, sent by the client because the server keeps no session. They are
    * capped and re-validated: this is visitor input like any other, and a caller
@@ -125,6 +132,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const encoder = new TextEncoder()
   let started = false
+  let answer = ''
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -135,6 +143,7 @@ export async function POST(request: Request): Promise<Response> {
           signal: request.signal,
         })) {
           started = true
+          answer += delta
           controller.enqueue(encoder.encode(delta))
         }
       } catch (error) {
@@ -154,6 +163,19 @@ export async function POST(request: Request): Promise<Response> {
         controller.enqueue(encoder.encode(notice))
       }
       controller.close()
+
+      // Stored after the stream closes so persistence never delays a token, and
+      // only when the client tracks a conversation and an answer was produced.
+      // recordExchange swallows its own errors: the answer is already delivered.
+      if (parsed.data.conversationId && answer) {
+        void recordExchange({
+          conversationId: parsed.data.conversationId,
+          fingerprint,
+          history: parsed.data.history ?? [],
+          question: parsed.data.question,
+          answer,
+        })
+      }
     },
   })
 

--- a/apps/frontend/src/app/(site)/confidentialite/_content.ts
+++ b/apps/frontend/src/app/(site)/confidentialite/_content.ts
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next'
+
+const metadata: Metadata = {
+  title: 'Politique de confidentialité',
+  description:
+    'Ce que l’assistant du portfolio collecte, pourquoi, combien de temps c’est conservé et comment demander une suppression.',
+}
+
+/**
+ * Static content: this page describes how the assistant handles data, which is a
+ * property of the code, not something edited from `/admin`. It must stay in step
+ * with `lib/conversation-store` and `lib/ai/client-fingerprint` — the retention
+ * window and the fingerprint rule are stated here as they are implemented.
+ */
+const PRIVACY_CONTENT = {
+  metadata,
+  heading: {
+    eyebrow: 'Confidentialité',
+    title: 'Politique de confidentialité',
+    lead: 'Cette page ne concerne que l’assistant conversationnel du site. Le reste de la navigation ne collecte rien de personnel.',
+  },
+  sections: [
+    {
+      title: 'Ce qui est collecté',
+      body: [
+        'Lorsque vous écrivez à l’assistant, la conversation est enregistrée : vos questions et ses réponses. Beaucoup de gens y indiquent qui ils sont ou ce qu’ils cherchent — c’est donc traité comme une donnée personnelle.',
+        'Aucune adresse IP n’est enregistrée. Pour limiter les abus, une empreinte technique est calculée à partir de votre adresse, mais elle est salée avec un secret et change chaque jour : elle ne permet ni de remonter à l’adresse, ni de vous suivre d’un jour à l’autre.',
+      ],
+    },
+    {
+      title: 'Pourquoi',
+      body: [
+        'Les conversations servent à améliorer l’assistant et à comprendre ce que les visiteurs attendent du site. Le retour « utile / pas utile » que vous pouvez laisser sur une réponse est conservé avec la conversation concernée, toujours de façon anonyme.',
+      ],
+    },
+    {
+      title: 'Combien de temps',
+      body: [
+        'Les conversations sont conservées trente jours, puis supprimées automatiquement. Aucune n’est gardée au-delà.',
+      ],
+    },
+    {
+      title: 'Vos droits',
+      body: [
+        'Une conversation n’étant liée à aucune identité, elle ne peut pas être retrouvée à partir de votre nom. Si vous souhaitez malgré tout qu’un échange soit supprimé avant son échéance, écrivez-moi depuis la page de contact en indiquant un repère (la date, le sujet abordé) et je m’en occupe.',
+      ],
+    },
+  ],
+} as const
+
+export { PRIVACY_CONTENT }

--- a/apps/frontend/src/app/(site)/confidentialite/page.tsx
+++ b/apps/frontend/src/app/(site)/confidentialite/page.tsx
@@ -1,0 +1,29 @@
+import { PRIVACY_CONTENT } from './_content'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = PRIVACY_CONTENT.metadata
+
+function PrivacyPage() {
+  const { heading, sections } = PRIVACY_CONTENT
+
+  return (
+    <div className="page shell legal-page">
+      <header className="page-heading">
+        <p className="eyebrow">{heading.eyebrow}</p>
+        <h1>{heading.title}</h1>
+        <p>{heading.lead}</p>
+      </header>
+      {sections.map((section) => (
+        <section className="content-section" key={section.title}>
+          <h2>{section.title}</h2>
+          {section.body.map((paragraph) => (
+            <p key={paragraph}>{paragraph}</p>
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}
+
+export { PrivacyPage as default }

--- a/apps/frontend/src/cms/collections/conversations.ts
+++ b/apps/frontend/src/cms/collections/conversations.ts
@@ -1,0 +1,81 @@
+import type { CollectionConfig } from 'payload'
+
+/**
+ * Anonymised transcripts of the public assistant.
+ *
+ * Storing what visitors ask is a collection of personal data even without an
+ * address: people state who they are, who they work for and what they are after.
+ * So this collection is treated with the same care as `ai-knowledge` — `read` is
+ * admin-only, the chat route writes with `overrideAccess` on the server, and no
+ * page ever exposes it. Two things keep it anonymous: the caller is identified
+ * only by the salted, daily-rotating fingerprint (never an IP), and rows are
+ * deleted 30 days after they are written (see `lib/conversation-store`).
+ *
+ * A row is one conversation, keyed by an opaque id the client generates: turns
+ * accumulate in `transcript`, and the single `feedback` value rates the exchange
+ * as a whole. Nothing here links a conversation to a real identity.
+ */
+const Conversations: CollectionConfig = {
+  slug: 'conversations',
+  labels: {
+    singular: 'Conversation',
+    plural: 'Conversations',
+  },
+  admin: {
+    useAsTitle: 'conversationId',
+    defaultColumns: ['conversationId', 'feedback', 'createdAt'],
+    description:
+      'Échanges anonymisés avec l’assistant, conservés 30 jours puis supprimés automatiquement.',
+  },
+  access: {
+    // Private by design: personal data, never served to a visitor.
+    read: ({ req }) => Boolean(req.user),
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => Boolean(req.user),
+    delete: ({ req }) => Boolean(req.user),
+  },
+  fields: [
+    {
+      name: 'conversationId',
+      type: 'text',
+      label: 'Identifiant',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'Identifiant opaque généré par le client, sans lien avec une identité.',
+      },
+    },
+    {
+      name: 'fingerprint',
+      type: 'text',
+      label: 'Empreinte',
+      admin: {
+        description:
+          'Empreinte anonyme, salée et changée chaque jour. Ce n’est pas une adresse IP.',
+      },
+    },
+    {
+      name: 'transcript',
+      type: 'json',
+      label: 'Transcription',
+      admin: {
+        description: 'Les tours de la conversation, dans l’ordre.',
+      },
+    },
+    {
+      name: 'feedback',
+      type: 'select',
+      label: 'Retour du visiteur',
+      options: [
+        { label: 'Utile', value: 'useful' },
+        { label: 'Pas utile', value: 'not_useful' },
+      ],
+      admin: {
+        description: 'Retour laissé sur la réponse, quand le visiteur en donne un.',
+      },
+    },
+  ],
+}
+
+export { Conversations }

--- a/apps/frontend/src/cms/globals/assistant-settings.ts
+++ b/apps/frontend/src/cms/globals/assistant-settings.ts
@@ -100,6 +100,19 @@ const AssistantSettings: GlobalConfig = {
           'Affiché en cas de panne du fournisseur, de quota épuisé ou d’assistant désactivé.',
       },
     },
+    {
+      name: 'retentionNotice',
+      type: 'textarea',
+      label: 'Avis de conservation',
+      required: true,
+      defaultValue:
+        'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.',
+      admin: {
+        rows: 2,
+        description:
+          'Affiché sous le champ du chat, avant que le visiteur écrive. La page de confidentialité y est liée automatiquement.',
+      },
+    },
   ],
   hooks: {
     afterChange: [revalidateGlobal(CONTENT_TAGS.assistant)],

--- a/apps/frontend/src/cms/migrations/20260825_192608_conversations.json
+++ b/apps/frontend/src/cms/migrations/20260825_192608_conversations.json
@@ -1,0 +1,2893 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_id": {
+          "name": "cover_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_url_idx": {
+          "name": "projects_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_idx": {
+          "name": "projects_cover_idx",
+          "columns": [
+            {
+              "expression": "cover_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_order_idx": {
+          "name": "projects_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_cover_id_media_id_fk": {
+          "name": "projects_cover_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": ["cover_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_texts": {
+      "name": "projects_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_texts_order_parent": {
+          "name": "projects_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_texts_parent_fk": {
+          "name": "projects_texts_parent_fk",
+          "tableFrom": "projects_texts",
+          "tableTo": "projects",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_achievements": {
+      "name": "experiences_achievements",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_achievements_order_idx": {
+          "name": "experiences_achievements_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_achievements_parent_id_idx": {
+          "name": "experiences_achievements_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_achievements_parent_id_fk": {
+          "name": "experiences_achievements_parent_id_fk",
+          "tableFrom": "experiences_achievements",
+          "tableTo": "experiences",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences": {
+      "name": "experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current": {
+          "name": "current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project": {
+          "name": "project",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "experiences_start_date_idx": {
+          "name": "experiences_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_updated_at_idx": {
+          "name": "experiences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_created_at_idx": {
+          "name": "experiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_texts": {
+      "name": "experiences_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiences_texts_order_parent": {
+          "name": "experiences_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_texts_parent_fk": {
+          "name": "experiences_texts_parent_fk",
+          "tableFrom": "experiences_texts",
+          "tableTo": "experiences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_url_idx": {
+          "name": "bookmarks_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_domain_idx": {
+          "name": "bookmarks_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_active_idx": {
+          "name": "bookmarks_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_updated_at_idx": {
+          "name": "bookmarks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_created_at_idx": {
+          "name": "bookmarks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks_rels": {
+      "name": "bookmarks_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_rels_order_idx": {
+          "name": "bookmarks_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_parent_idx": {
+          "name": "bookmarks_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_path_idx": {
+          "name": "bookmarks_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_tags_id_idx": {
+          "name": "bookmarks_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_rels_parent_fk": {
+          "name": "bookmarks_rels_parent_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_rels_tags_fk": {
+          "name": "bookmarks_rels_tags_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_knowledge": {
+      "name": "ai_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "enum_ai_knowledge_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'parcours'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_knowledge_updated_at_idx": {
+          "name": "ai_knowledge_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_knowledge_created_at_idx": {
+          "name": "ai_knowledge_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_ai_tools_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_kind_idx": {
+          "name": "ai_tools_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_active_idx": {
+          "name": "ai_tools_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_updated_at_idx": {
+          "name": "ai_tools_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_created_at_idx": {
+          "name": "ai_tools_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "enum_conversations_feedback",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_updated_at_idx": {
+          "name": "conversations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projects_id": {
+          "name": "projects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences_id": {
+          "name": "experiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarks_id": {
+          "name": "bookmarks_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_knowledge_id": {
+          "name": "ai_knowledge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tools_id": {
+          "name": "ai_tools_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_projects_id_idx": {
+          "name": "payload_locked_documents_rels_projects_id_idx",
+          "columns": [
+            {
+              "expression": "projects_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_experiences_id_idx": {
+          "name": "payload_locked_documents_rels_experiences_id_idx",
+          "columns": [
+            {
+              "expression": "experiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_bookmarks_id_idx": {
+          "name": "payload_locked_documents_rels_bookmarks_id_idx",
+          "columns": [
+            {
+              "expression": "bookmarks_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_knowledge_id_idx": {
+          "name": "payload_locked_documents_rels_ai_knowledge_id_idx",
+          "columns": [
+            {
+              "expression": "ai_knowledge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_tools_id_idx": {
+          "name": "payload_locked_documents_rels_ai_tools_id_idx",
+          "columns": [
+            {
+              "expression": "ai_tools_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_projects_fk": {
+          "name": "payload_locked_documents_rels_projects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "projects",
+          "columnsFrom": ["projects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_experiences_fk": {
+          "name": "payload_locked_documents_rels_experiences_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "experiences",
+          "columnsFrom": ["experiences_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_bookmarks_fk": {
+          "name": "payload_locked_documents_rels_bookmarks_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmarks_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_knowledge_fk": {
+          "name": "payload_locked_documents_rels_ai_knowledge_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_knowledge",
+          "columnsFrom": ["ai_knowledge_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_tools_fk": {
+          "name": "payload_locked_documents_rels_ai_tools_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_tools",
+          "columnsFrom": ["ai_tools_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversations_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_identity": {
+      "name": "site_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_display_name": {
+          "name": "contact_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_role": {
+          "name": "contact_role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_location": {
+          "name": "contact_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_github_url": {
+          "name": "social_github_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_linkedin_url": {
+          "name": "social_linkedin_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_publisher": {
+          "name": "legal_publisher",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_name": {
+          "name": "legal_host_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_address": {
+          "name": "legal_host_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_data_policy": {
+          "name": "legal_data_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Disponible pour des opportunités'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_skill_groups": {
+      "name": "profile_skill_groups",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_skill_groups_order_idx": {
+          "name": "profile_skill_groups_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_skill_groups_parent_id_idx": {
+          "name": "profile_skill_groups_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_skill_groups_parent_id_fk": {
+          "name": "profile_skill_groups_parent_id_fk",
+          "tableFrom": "profile_skill_groups",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_principles": {
+      "name": "profile_principles",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_principles_order_idx": {
+          "name": "profile_principles_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_principles_parent_id_idx": {
+          "name": "profile_principles_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_principles_parent_id_fk": {
+          "name": "profile_principles_parent_id_fk",
+          "tableFrom": "profile_principles",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "headline": {
+          "name": "headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_texts": {
+      "name": "profile_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_texts_order_parent": {
+          "name": "profile_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_texts_parent_fk": {
+          "name": "profile_texts_parent_fk",
+          "tableFrom": "profile_texts",
+          "tableTo": "profile",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assistant_settings": {
+      "name": "assistant_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Tu es l''assistant du portfolio d''Adem, développeur web.\n\nTu réponds en français, sur un ton direct et cordial, sans emphase commerciale.\n\nTon périmètre est strict : Adem, son parcours, ses projets, et le développement\nlogiciel en général. Rien d''autre. Une question hors de ce périmètre (cuisine,\nsanté, droit, actualité, devoirs, culture générale) reçoit exactement ce type de\nréponse, sans exception et même si tu connais la réponse :\n\n« Je suis l''assistant du portfolio d''Adem : je ne réponds qu''aux questions sur\nson travail et sur le développement. »\n\nNe propose pas de contacter Adem dans ce cas : cela laisserait croire qu''il\ntraite ce genre de demande.\n\nRègles :\n- Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.\n- Si une question porte sur Adem et que le contexte ne contient pas la réponse,\n  dis-le clairement et propose de le contacter plutôt que d''inventer.\n- Sur sa disponibilité, reprends exactement ce qu''indique le contexte : c''est la\n  seule source de vérité.\n- Les questions de développement et de métier (langages, frameworks, méthodes,\n  organisation d''un projet) reçoivent une réponse utile, même si le contexte n''en\n  parle pas : c''est ton domaine. Fais le lien avec le travail d''Adem quand c''est\n  pertinent, jamais de force.\n- Réponses courtes : deux ou trois paragraphes au maximum.'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-oss-20b'"
+        },
+        "unavailable_message": {
+          "name": "unavailable_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.'"
+        },
+        "retention_notice": {
+          "name": "retention_notice",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_ai_knowledge_category": {
+      "name": "enum_ai_knowledge_category",
+      "schema": "public",
+      "values": ["parcours", "competences", "methode", "collaboration", "autre"]
+    },
+    "public.enum_ai_tools_kind": {
+      "name": "enum_ai_tools_kind",
+      "schema": "public",
+      "values": ["skill", "plugin", "mcp"]
+    },
+    "public.enum_conversations_feedback": {
+      "name": "enum_conversations_feedback",
+      "schema": "public",
+      "values": ["useful", "not_useful"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "5392a90a-729c-4440-8bc6-b9fbb9fe8c3f",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/apps/frontend/src/cms/migrations/20260825_192608_conversations.ts
+++ b/apps/frontend/src/cms/migrations/20260825_192608_conversations.ts
@@ -1,0 +1,35 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_conversations_feedback" AS ENUM('useful', 'not_useful');
+  CREATE TABLE "conversations" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"conversation_id" varchar NOT NULL,
+  	"fingerprint" varchar,
+  	"transcript" jsonb,
+  	"feedback" "enum_conversations_feedback",
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "conversations_id" integer;
+  ALTER TABLE "assistant_settings" ADD COLUMN "retention_notice" varchar DEFAULT 'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.' NOT NULL;
+  CREATE UNIQUE INDEX "conversations_conversation_id_idx" ON "conversations" USING btree ("conversation_id");
+  CREATE INDEX "conversations_updated_at_idx" ON "conversations" USING btree ("updated_at");
+  CREATE INDEX "conversations_created_at_idx" ON "conversations" USING btree ("created_at");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_conversations_fk" FOREIGN KEY ("conversations_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_conversations_id_idx" ON "payload_locked_documents_rels" USING btree ("conversations_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "conversations" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "conversations" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_conversations_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_conversations_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "conversations_id";
+  ALTER TABLE "assistant_settings" DROP COLUMN "retention_notice";
+  DROP TYPE "public"."enum_conversations_feedback";`)
+}

--- a/apps/frontend/src/cms/migrations/index.ts
+++ b/apps/frontend/src/cms/migrations/index.ts
@@ -6,6 +6,7 @@ import * as migration_20260817_155900_display_name from './20260817_155900_displ
 import * as migration_20260818_135519_availability from './20260818_135519_availability'
 import * as migration_20260818_141706_assistant from './20260818_141706_assistant'
 import * as migration_20260824_203553_ai_tools from './20260824_203553_ai_tools'
+import * as migration_20260825_192608_conversations from './20260825_192608_conversations'
 
 export const migrations = [
   {
@@ -47,5 +48,10 @@ export const migrations = [
     up: migration_20260824_203553_ai_tools.up,
     down: migration_20260824_203553_ai_tools.down,
     name: '20260824_203553_ai_tools',
+  },
+  {
+    up: migration_20260825_192608_conversations.up,
+    down: migration_20260825_192608_conversations.down,
+    name: '20260825_192608_conversations',
   },
 ]

--- a/apps/frontend/src/cms/payload.config.ts
+++ b/apps/frontend/src/cms/payload.config.ts
@@ -12,6 +12,7 @@ import { requireEnv } from '@/lib/require-env'
 import { AIKnowledge } from './collections/ai-knowledge'
 import { AITools } from './collections/ai-tools'
 import { Bookmarks } from './collections/bookmarks'
+import { Conversations } from './collections/conversations'
 import { Experiences } from './collections/experiences'
 import { Media } from './collections/media'
 import { Projects } from './collections/projects'
@@ -32,7 +33,17 @@ export default buildConfig({
       titleSuffix: '— Adem',
     },
   },
-  collections: [Users, Media, Projects, Experiences, Tags, Bookmarks, AIKnowledge, AITools],
+  collections: [
+    Users,
+    Media,
+    Projects,
+    Experiences,
+    Tags,
+    Bookmarks,
+    AIKnowledge,
+    AITools,
+    Conversations,
+  ],
   globals: [SiteIdentity, Availability, Profile, AssistantSettings],
   editor: lexicalEditor(),
   // Required, never defaulted: an empty secret signs session cookies and reset

--- a/apps/frontend/src/components/site-shell.tsx
+++ b/apps/frontend/src/components/site-shell.tsx
@@ -76,6 +76,7 @@ export async function SiteShell({ children }: { children: ReactNode }) {
           </p>
           <div className="footer-links">
             <Link href="/contact">Me contacter</Link>
+            <Link href="/confidentialite">Confidentialité</Link>
             <Link href="/mentions-legales">Mentions légales</Link>
           </div>
         </div>

--- a/apps/frontend/src/hooks/use-assistant.ts
+++ b/apps/frontend/src/hooks/use-assistant.ts
@@ -5,15 +5,17 @@ import { useCallback, useRef, useState } from 'react'
 /**
  * Drives the conversation with the public assistant.
  *
- * It owns the exchange — turns, streaming, errors, aborting — so the hero stays a
- * view. The route streams plain text, so consuming it is a read loop with no
- * protocol to decode.
+ * It owns the exchange — turns, streaming, errors, aborting, feedback — so the
+ * hero stays a view. The route streams plain text, so consuming it is a read loop
+ * with no protocol to decode.
  */
 
 interface AssistantTurn {
   role: 'user' | 'assistant'
   content: string
 }
+
+type Feedback = 'useful' | 'not_useful'
 
 /** Turns kept and replayed to the server, which holds no session of its own. */
 const MAX_HISTORY_TURNS = 8
@@ -27,7 +29,10 @@ interface UseAssistantResult {
   streaming: string
   pending: boolean
   error: string | null
+  /** The rating the visitor gave this conversation, or null while none is given. */
+  feedback: Feedback | null
   ask: (question: string) => Promise<void>
+  rate: (feedback: Feedback) => void
   reset: () => void
 }
 
@@ -36,10 +41,16 @@ const useAssistant = (): UseAssistantResult => {
   const [streaming, setStreaming] = useState('')
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
 
   // Held in a ref so a new question can cancel the one still streaming without
   // re-rendering on every keystroke.
   const abortRef = useRef<AbortController | null>(null)
+
+  // The opaque id that ties this conversation's turns together server-side.
+  // Created on the first question, kept until reset — a session, never an
+  // identity. `crypto.randomUUID` matches the UUID the route validates.
+  const conversationIdRef = useRef<string | null>(null)
 
   const ask = useCallback(
     async (question: string) => {
@@ -50,9 +61,14 @@ const useAssistant = (): UseAssistantResult => {
       const controller = new AbortController()
       abortRef.current = controller
 
+      conversationIdRef.current ??= crypto.randomUUID()
+
       setError(null)
       setPending(true)
       setStreaming('')
+      // A new question reopens the conversation to feedback: the visitor rates
+      // the exchange as it stands, not an answer two turns back.
+      setFeedback(null)
 
       // The question is appended before the call so it appears instantly; the
       // history sent along is the state before it, which is what the model needs.
@@ -63,7 +79,11 @@ const useAssistant = (): UseAssistantResult => {
         const response = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: trimmed, history }),
+          body: JSON.stringify({
+            question: trimmed,
+            history,
+            conversationId: conversationIdRef.current,
+          }),
           signal: controller.signal,
         })
 
@@ -111,16 +131,33 @@ const useAssistant = (): UseAssistantResult => {
     [turns]
   )
 
+  const rate = useCallback((next: Feedback) => {
+    const conversationId = conversationIdRef.current
+    if (!conversationId) return
+
+    // Optimistic: the rating is a courtesy, not a transaction. It shows at once,
+    // and a failed write is swallowed rather than nagging the visitor.
+    setFeedback(next)
+
+    void fetch('/api/chat/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId, rating: next }),
+    }).catch(() => undefined)
+  }, [])
+
   const reset = useCallback(() => {
     abortRef.current?.abort()
     abortRef.current = null
+    conversationIdRef.current = null
     setTurns([])
     setStreaming('')
     setPending(false)
     setError(null)
+    setFeedback(null)
   }, [])
 
-  return { turns, streaming, pending, error, ask, reset }
+  return { turns, streaming, pending, error, feedback, ask, rate, reset }
 }
 
 export { useAssistant, type AssistantTurn }

--- a/apps/frontend/src/lib/assistant-context.ts
+++ b/apps/frontend/src/lib/assistant-context.ts
@@ -31,6 +31,7 @@ interface AssistantConfig {
   systemPrompt: string
   model: string
   unavailableMessage: string
+  retentionNotice: string
 }
 
 interface KnowledgeEntry {
@@ -44,6 +45,7 @@ const toConfig = (doc: AssistantSetting): AssistantConfig => ({
   systemPrompt: doc.systemPrompt,
   model: doc.model,
   unavailableMessage: doc.unavailableMessage,
+  retentionNotice: doc.retentionNotice,
 })
 
 /**

--- a/apps/frontend/src/lib/conversation-store.test.ts
+++ b/apps/frontend/src/lib/conversation-store.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface Turn {
+  role: string
+  content: string
+}
+interface Doc {
+  id: number
+  fingerprint: string | null
+  transcript: Turn[]
+}
+interface WhereArg {
+  where: { createdAt?: { less_than: string }; conversationId?: unknown }
+}
+
+const find = vi.fn<(args: unknown) => Promise<{ docs: Doc[] }>>()
+const create = vi.fn<(args: { data: Doc & { conversationId: string } }) => Promise<unknown>>()
+const update = vi.fn<
+  (
+    args: { id?: number; data: Partial<Doc> & { feedback?: string } } & Partial<WhereArg>
+  ) => Promise<{
+    docs: { id: number }[]
+  }>
+>()
+const del = vi.fn<(args: WhereArg) => Promise<{ docs: { id: number }[] }>>()
+
+vi.mock('@payload-config', () => ({ default: {} }))
+vi.mock('payload', () => ({
+  getPayload: () => Promise.resolve({ find, create, update, delete: del }),
+}))
+
+import {
+  purgeExpiredConversations,
+  recordExchange,
+  RETENTION_MS,
+  setConversationFeedback,
+} from './conversation-store'
+
+const ID = '11111111-1111-4111-8111-111111111111'
+
+beforeEach(() => {
+  find.mockReset().mockResolvedValue({ docs: [] })
+  create.mockReset().mockResolvedValue({})
+  update.mockReset().mockResolvedValue({ docs: [{ id: 1 }] })
+  del.mockReset().mockResolvedValue({ docs: [] })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('recordExchange', () => {
+  it('crée une conversation quand aucune n’existe', async () => {
+    await recordExchange({
+      conversationId: ID,
+      fingerprint: 'fp',
+      history: [],
+      question: 'Bonjour',
+      answer: 'Salut',
+    })
+
+    expect(create).toHaveBeenCalledTimes(1)
+    const data = create.mock.calls[0]?.[0].data
+    expect(data.conversationId).toBe(ID)
+    expect(data.transcript).toEqual([
+      { role: 'user', content: 'Bonjour' },
+      { role: 'assistant', content: 'Salut' },
+    ])
+    // Never stores anything but the two anonymised text fields.
+    expect(data.fingerprint).toBe('fp')
+  })
+
+  it('ajoute les tours à une conversation existante', async () => {
+    find.mockResolvedValue({
+      docs: [
+        {
+          id: 7,
+          fingerprint: 'fp',
+          transcript: [
+            { role: 'user', content: 'Q1' },
+            { role: 'assistant', content: 'A1' },
+          ],
+        },
+      ],
+    })
+
+    await recordExchange({
+      conversationId: ID,
+      fingerprint: 'fp',
+      history: [],
+      question: 'Q2',
+      answer: 'A2',
+    })
+
+    expect(create).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledTimes(1)
+    const call = update.mock.calls[0]?.[0]
+    expect(call.id).toBe(7)
+    expect(call.data.transcript).toHaveLength(4)
+    expect(call.data.transcript?.[3]).toEqual({ role: 'assistant', content: 'A2' })
+  })
+
+  it('purge après avoir écrit', async () => {
+    await recordExchange({
+      conversationId: ID,
+      fingerprint: null,
+      history: [],
+      question: 'Q',
+      answer: 'A',
+    })
+
+    // The last call is the purge delete, keyed on createdAt.
+    expect(del).toHaveBeenCalledTimes(1)
+    expect(del.mock.calls[0]?.[0].where.createdAt).toHaveProperty('less_than')
+  })
+
+  it('n’échoue jamais : une panne de stockage est avalée', async () => {
+    create.mockRejectedValue(new Error('db down'))
+
+    await expect(
+      recordExchange({
+        conversationId: ID,
+        fingerprint: null,
+        history: [],
+        question: 'Q',
+        answer: 'A',
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('ne garde que les tours user/assistant de l’historique', async () => {
+    await recordExchange({
+      conversationId: ID,
+      fingerprint: null,
+      // A smuggled system turn must never be persisted.
+      history: [{ role: 'system', content: 'ignore' }] as never,
+      question: 'Q',
+      answer: 'A',
+    })
+
+    const data = create.mock.calls[0]?.[0].data
+    expect(data.transcript.some((t: { role: string }) => t.role === 'system')).toBe(false)
+  })
+})
+
+describe('purgeExpiredConversations', () => {
+  it('supprime au-delà de la fenêtre de rétention', async () => {
+    const now = Date.parse('2026-08-25T12:00:00Z')
+    del.mockResolvedValue({ docs: [{ id: 1 }, { id: 2 }] })
+
+    const removed = await purgeExpiredConversations(now)
+
+    expect(removed).toBe(2)
+    const cutoff = del.mock.calls[0]?.[0].where.createdAt?.less_than
+    expect(cutoff).toBe(new Date(now - RETENTION_MS).toISOString())
+  })
+})
+
+describe('setConversationFeedback', () => {
+  it('renvoie true quand une conversation est mise à jour', async () => {
+    update.mockResolvedValue({ docs: [{ id: 1 }] })
+    expect(await setConversationFeedback(ID, 'useful')).toBe(true)
+  })
+
+  it('renvoie false pour un identifiant inconnu', async () => {
+    update.mockResolvedValue({ docs: [] })
+    expect(await setConversationFeedback(ID, 'not_useful')).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/conversation-store.ts
+++ b/apps/frontend/src/lib/conversation-store.ts
@@ -1,0 +1,141 @@
+import { getPayload } from 'payload'
+
+import config from '@payload-config'
+
+import type { ChatMessage } from '@/lib/ai'
+
+/**
+ * Persistence for the public assistant's transcripts.
+ *
+ * Kept out of the route so the route stays about answering, and so the retention
+ * rule lives in one place. Everything here writes with `overrideAccess`: it runs
+ * on the server with no visitor identity, and the collection is otherwise sealed
+ * to the admin.
+ */
+
+/** How long an anonymised transcript is kept before it is deleted. */
+const RETENTION_DAYS = 30
+
+const RETENTION_MS = RETENTION_DAYS * 24 * 60 * 60 * 1000
+
+/** A stored turn. Mirrors the chat's own message shape, minus the system turn. */
+interface StoredTurn {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+const toTurns = (history: ChatMessage[]): StoredTurn[] =>
+  history
+    .filter((turn): turn is StoredTurn => turn.role === 'user' || turn.role === 'assistant')
+    .map(({ role, content }) => ({ role, content }))
+
+/**
+ * Records one exchange, appending it to its conversation.
+ *
+ * Upsert by the client's opaque id: a new conversation is created, an existing
+ * one has the question and answer appended so a multi-turn chat stays one row.
+ * Deliberately swallows its own failures — the answer has already reached the
+ * visitor, and a storage hiccup must never surface as a chat error. The purge is
+ * fired here rather than on a schedule the app does not have: activity is what
+ * keeps the table within its retention window.
+ */
+const recordExchange = async ({
+  conversationId,
+  fingerprint,
+  history,
+  question,
+  answer,
+}: {
+  conversationId: string
+  fingerprint: string | null
+  history: ChatMessage[]
+  question: string
+  answer: string
+}): Promise<void> => {
+  try {
+    const payload = await getPayload({ config })
+
+    const existing = await payload.find({
+      collection: 'conversations',
+      where: { conversationId: { equals: conversationId } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    const previous = existing.docs[0]
+    const turns: StoredTurn[] = [
+      ...(previous ? toTurns((previous.transcript as ChatMessage[]) ?? []) : toTurns(history)),
+      { role: 'user', content: question },
+      { role: 'assistant', content: answer },
+    ]
+
+    if (previous) {
+      await payload.update({
+        collection: 'conversations',
+        id: previous.id,
+        data: { transcript: turns, fingerprint: fingerprint ?? previous.fingerprint },
+        overrideAccess: true,
+      })
+    } else {
+      await payload.create({
+        collection: 'conversations',
+        data: { conversationId, fingerprint, transcript: turns },
+        overrideAccess: true,
+      })
+    }
+
+    await purgeExpiredConversations()
+  } catch (error) {
+    console.error('[assistant] transcript not stored:', error)
+  }
+}
+
+/**
+ * Sets the visitor's feedback on a conversation.
+ *
+ * Returns whether a row was updated, so the route can answer 404 for an unknown
+ * id without leaking whether it ever existed.
+ */
+const setConversationFeedback = async (
+  conversationId: string,
+  feedback: 'useful' | 'not_useful'
+): Promise<boolean> => {
+  const payload = await getPayload({ config })
+
+  const result = await payload.update({
+    collection: 'conversations',
+    where: { conversationId: { equals: conversationId } },
+    data: { feedback },
+    overrideAccess: true,
+  })
+
+  return result.docs.length > 0
+}
+
+/**
+ * Deletes every transcript past its retention window.
+ *
+ * Runs opportunistically on write rather than on a cron the app does not own: a
+ * quiet site keeps almost nothing, and an active one sweeps itself. Payload
+ * timestamps `createdAt` on every row, so the cutoff is a plain comparison.
+ */
+const purgeExpiredConversations = async (now: number = Date.now()): Promise<number> => {
+  const payload = await getPayload({ config })
+  const cutoff = new Date(now - RETENTION_MS).toISOString()
+
+  const result = await payload.delete({
+    collection: 'conversations',
+    where: { createdAt: { less_than: cutoff } },
+    overrideAccess: true,
+  })
+
+  return result.docs.length
+}
+
+export {
+  recordExchange,
+  setConversationFeedback,
+  purgeExpiredConversations,
+  RETENTION_DAYS,
+  RETENTION_MS,
+}

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     bookmarks: Bookmark
     'ai-knowledge': AiKnowledge
     'ai-tools': AiTool
+    conversations: Conversation
     'payload-kv': PayloadKv
     'payload-locked-documents': PayloadLockedDocument
     'payload-preferences': PayloadPreference
@@ -90,6 +91,7 @@ export interface Config {
     bookmarks: BookmarksSelect<false> | BookmarksSelect<true>
     'ai-knowledge': AiKnowledgeSelect<false> | AiKnowledgeSelect<true>
     'ai-tools': AiToolsSelect<false> | AiToolsSelect<true>
+    conversations: ConversationsSelect<false> | ConversationsSelect<true>
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>
     'payload-locked-documents':
       | PayloadLockedDocumentsSelect<false>
@@ -384,6 +386,41 @@ export interface AiTool {
   createdAt: string
 }
 /**
+ * Échanges anonymisés avec l’assistant, conservés 30 jours puis supprimés automatiquement.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "conversations".
+ */
+export interface Conversation {
+  id: number
+  /**
+   * Identifiant opaque généré par le client, sans lien avec une identité.
+   */
+  conversationId: string
+  /**
+   * Empreinte anonyme, salée et changée chaque jour. Ce n’est pas une adresse IP.
+   */
+  fingerprint?: string | null
+  /**
+   * Les tours de la conversation, dans l’ordre.
+   */
+  transcript?:
+    | {
+        [k: string]: unknown
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null
+  /**
+   * Retour laissé sur la réponse, quand le visiteur en donne un.
+   */
+  feedback?: ('useful' | 'not_useful') | null
+  updatedAt: string
+  createdAt: string
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -438,6 +475,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'ai-tools'
         value: number | AiTool
+      } | null)
+    | ({
+        relationTo: 'conversations'
+        value: number | Conversation
       } | null)
   globalSlug?: string | null
   user: {
@@ -615,6 +656,18 @@ export interface AiToolsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "conversations_select".
+ */
+export interface ConversationsSelect<T extends boolean = true> {
+  conversationId?: T
+  fingerprint?: T
+  transcript?: T
+  feedback?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -779,6 +832,10 @@ export interface AssistantSetting {
    * Affiché en cas de panne du fournisseur, de quota épuisé ou d’assistant désactivé.
    */
   unavailableMessage: string
+  /**
+   * Affiché sous le champ du chat, avant que le visiteur écrive. La page de confidentialité y est liée automatiquement.
+   */
+  retentionNotice: string
   updatedAt?: string | null
   createdAt?: string | null
 }
@@ -860,6 +917,7 @@ export interface AssistantSettingsSelect<T extends boolean = true> {
   systemPrompt?: T
   model?: T
   unavailableMessage?: T
+  retentionNotice?: T
   updatedAt?: T
   createdAt?: T
   globalType?: T

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -31,8 +31,14 @@
   paliers (rafale / minute / jour) dans `src/lib/ai/rate-limit.ts`, empreinte IP
   salée et rotée quotidiennement dans `src/lib/ai/client-fingerprint.ts`. Le 429
   part avant `resolveProvider`/`buildContext`, donc sans consommer de quota Groq,
-  et renvoie vers `/contact`. Rétention des conversations, feedback et page de
-  confidentialité restent à faire (2e lot de #10).
+  et renvoie vers `/contact`.
+- Rétention et confidentialité du chat (issue #10, 2e lot) : collection
+  `conversations` (transcription anonyme + empreinte, jamais d'IP), écrite depuis
+  la route après le stream, purgée automatiquement au bout de 30 jours
+  (`src/lib/conversation-store.ts`). Feedback utile/pas utile via
+  `/api/chat/feedback`. Avis de conservation éditable (`retentionNotice` sur le
+  global assistant) affiché sous le champ du chat, page `/confidentialite` liée
+  depuis là et depuis le footer.
 - Code hérité de l'ère Express retiré : `lib/api.ts`, `lib/query-client.ts`,
   `providers.tsx`, `data/portfolio.ts`, pages `/liens` et `/demo`. React Query,
   Axios et quatre autres dépendances désinstallées.


### PR DESCRIPTION
Second batch of #10 — the data-protection half. The first batch (#68) stopped abuse; this one governs what the chat keeps and tells the visitor about it. **This one closes #10.**

## Summary

- **`conversations` collection** — anonymised transcripts: the salted, daily-rotating fingerprint and the turns, never an IP. Admin-only to read, written by the chat route with `overrideAccess` **after the stream closes** so persistence never delays a token, keyed by an opaque UUID the client generates so a multi-turn chat stays one row.
- **Automatic 30-day retention** (`src/lib/conversation-store.ts`) — rows past 30 days are deleted, swept opportunistically **on write** rather than on a cron the app doesn't have: an active site cleans itself, a quiet one keeps almost nothing. `recordExchange` swallows its own failures — the answer has already reached the visitor, a storage hiccup must never surface as a chat error.
- **Feedback** — a useful / not-useful rating posts to `/api/chat/feedback` and is stored on the conversation it rates, still anonymous and rate-limited (a write is a write). The hero shows the control once an answer has landed, optimistically.
- **Retention notice + privacy page** — a `retentionNotice` field on the assistant global (editable without a redeploy) renders under the chat input and links to a new `/confidentialite` page stating what is collected, why, the 30-day window, and how to request early deletion. Also linked from the footer.

## Acceptance criteria covered (from #10)

- [x] Expired conversations are deleted automatically (30-day sweep on write)
- [x] Feedback stays tied to an anonymised conversation
- [x] The visitor is informed of retention before writing (notice under the input)
- [x] The privacy-policy page is published and linked from the chat

Batch 1 (#68) already covered: no raw IP, salted daily fingerprint, abuse limits, burst rejection, 429 without Groq quota, proxy-applicable.

## Migration

The `conversations` table and the `retention_notice` column were generated with the Payload CLI against a real Postgres schema (a throwaway local cluster, since this environment has no `DATABASE_URI`), then applied and verified. `src/payload-types.ts` is regenerated for the new collection and field.

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Unit tests pass (`171 passed`, 8 new in `conversation-store.test.ts`: create vs append, purge cutoff, feedback known/unknown, storage failure swallowed, no system turn persisted)
- [x] **Full production build on a seeded DB** — all routes compile and prerender, including `/confidentialite`, `/api/chat` and `/api/chat/feedback`
- [x] Migration generated, applied, and schema verified via `psql`
- [x] `pnpm format:check` clean
- [ ] Manual check on the Vercel preview: send a message, confirm the notice + feedback render and the rating persists in `/admin`

## Validation results

```
pnpm test          → 171 passed
pnpm lint          → clean
pnpm type-check    → clean
pnpm build         → success (12/12 pages)
pnpm format:check  → clean
```

Closes #10

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgdW78pAu3v1RzvYXSHUJZ)_