### PR TITLE
feat(backend): localize the editorial content and add its English translations

### DIFF
--- a/apps/frontend/src/app/[locale]/(site)/(home)/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/(home)/page.tsx
@@ -28,11 +28,11 @@ async function Home({ params }: PageProps<'/[locale]'>) {
   setRequestLocale(locale)
 
   const [identity, availability, profile, projects, assistant] = await Promise.all([
-    getIdentity(),
-    getAvailability(),
-    getProfile(),
-    listProjects(),
-    getAssistantConfig(),
+    getIdentity(locale),
+    getAvailability(locale),
+    getProfile(locale),
+    listProjects(locale),
+    getAssistantConfig(locale),
   ])
 
   // Without a project flagged as featured, show the first of the sort order

--- a/apps/frontend/src/app/[locale]/(site)/a-propos/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/a-propos/page.tsx
@@ -33,9 +33,9 @@ async function AboutPage({ params }: PageProps<'/[locale]/a-propos'>) {
   // Independent reads: they go out in parallel rather than in series.
   const [t, identity, profile, experiences] = await Promise.all([
     getTranslations('About'),
-    getIdentity(),
-    getProfile(),
-    listExperiences(),
+    getIdentity(locale),
+    getProfile(locale),
+    listExperiences(locale),
   ])
 
   return (

--- a/apps/frontend/src/app/[locale]/(site)/contact/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/contact/page.tsx
@@ -26,7 +26,7 @@ async function ContactPage({ params }: PageProps<'/[locale]/contact'>) {
   const locale = await getPageLocale(params)
   setRequestLocale(locale)
 
-  const [t, identity] = await Promise.all([getTranslations('Contact'), getIdentity()])
+  const [t, identity] = await Promise.all([getTranslations('Contact'), getIdentity(locale)])
 
   return (
     <div className="page shell">

--- a/apps/frontend/src/app/[locale]/(site)/mentions-legales/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/mentions-legales/page.tsx
@@ -23,7 +23,7 @@ async function LegalPage({ params }: PageProps<'/[locale]/mentions-legales'>) {
   const locale = await getPageLocale(params)
   setRequestLocale(locale)
 
-  const [t, identity] = await Promise.all([getTranslations('Legal'), getIdentity()])
+  const [t, identity] = await Promise.all([getTranslations('Legal'), getIdentity(locale)])
   const { legal } = identity
   const role = identity.location ? `${identity.role}, ${identity.location}` : identity.role
 

--- a/apps/frontend/src/app/[locale]/(site)/outils-ia/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/outils-ia/page.tsx
@@ -25,7 +25,7 @@ async function AIToolsPage({ params }: PageProps<'/[locale]/outils-ia'>) {
   const locale = await getPageLocale(params)
   setRequestLocale(locale)
 
-  const [t, tools] = await Promise.all([getTranslations('Tools'), listPublicAITools()])
+  const [t, tools] = await Promise.all([getTranslations('Tools'), listPublicAITools(locale)])
 
   return (
     <div className="page shell">

--- a/apps/frontend/src/app/[locale]/(site)/projets/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/projets/page.tsx
@@ -26,7 +26,7 @@ async function ProjectsPage({ params }: PageProps<'/[locale]/projets'>) {
   const locale = await getPageLocale(params)
   setRequestLocale(locale)
 
-  const [t, projects] = await Promise.all([getTranslations('Projects'), listProjects()])
+  const [t, projects] = await Promise.all([getTranslations('Projects'), listProjects(locale)])
 
   return (
     <div className="page shell">

--- a/apps/frontend/src/app/[locale]/(site)/veille/page.tsx
+++ b/apps/frontend/src/app/[locale]/(site)/veille/page.tsx
@@ -1,5 +1,5 @@
 import { headers } from 'next/headers'
-import { getTranslations } from 'next-intl/server'
+import { getLocale, getTranslations } from 'next-intl/server'
 import { getPayload } from 'payload'
 
 import { buildAlternates } from '@/i18n/metadata'
@@ -40,13 +40,16 @@ async function isOwner(): Promise<boolean> {
 }
 
 async function WatchPage() {
+  // Rendered on demand, so the locale comes from the request rather than params.
+  const locale = await getLocale()
+
   // Reading is public and the session only decides whether the editing controls
   // are rendered: the queries are independent.
   const [t, bookmarks, owner, allTags] = await Promise.all([
     getTranslations('Veille'),
-    listPublicBookmarks(),
+    listPublicBookmarks(locale),
     isOwner(),
-    listAllTags(),
+    listAllTags(locale),
   ])
 
   return (

--- a/apps/frontend/src/app/api/chat/route.ts
+++ b/apps/frontend/src/app/api/chat/route.ts
@@ -126,7 +126,7 @@ export async function POST(request: Request): Promise<Response> {
     }
   }
 
-  const settings = await getAssistantConfig()
+  const settings = await getAssistantConfig(locale)
   if (!settings.enabled) return fallbackResponse(settings.unavailableMessage)
 
   let provider
@@ -139,7 +139,7 @@ export async function POST(request: Request): Promise<Response> {
   }
   if (!provider) return fallbackResponse(settings.unavailableMessage)
 
-  const context = await buildContext()
+  const context = await buildContext(locale)
 
   const messages: ChatMessage[] = [
     {

--- a/apps/frontend/src/cms/collections/ai-knowledge.ts
+++ b/apps/frontend/src/cms/collections/ai-knowledge.ts
@@ -46,6 +46,7 @@ const AIKnowledge: CollectionConfig = {
     {
       name: 'question',
       type: 'text',
+      localized: true,
       label: 'Question',
       required: true,
       admin: {
@@ -55,6 +56,7 @@ const AIKnowledge: CollectionConfig = {
     {
       name: 'answer',
       type: 'textarea',
+      localized: true,
       label: 'Réponse',
       required: true,
       admin: {

--- a/apps/frontend/src/cms/collections/ai-tools.ts
+++ b/apps/frontend/src/cms/collections/ai-tools.ts
@@ -58,6 +58,7 @@ const AITools: CollectionConfig = {
     {
       name: 'description',
       type: 'textarea',
+      localized: true,
       label: 'Description',
       admin: {
         description: 'Une ou deux phrases : à quoi sert l’outil, pas comment il marche.',

--- a/apps/frontend/src/cms/collections/experiences.ts
+++ b/apps/frontend/src/cms/collections/experiences.ts
@@ -39,12 +39,14 @@ const Experiences: CollectionConfig = {
     {
       name: 'role',
       type: 'text',
+      localized: true,
       label: 'Poste',
       required: true,
     },
     {
       name: 'location',
       type: 'text',
+      localized: true,
       label: 'Lieu',
     },
     {
@@ -80,6 +82,7 @@ const Experiences: CollectionConfig = {
     {
       name: 'project',
       type: 'textarea',
+      localized: true,
       label: 'Produit',
       admin: {
         description: 'Optionnel : le produit sur lequel porte la mission.',
@@ -88,6 +91,7 @@ const Experiences: CollectionConfig = {
     {
       name: 'context',
       type: 'textarea',
+      localized: true,
       label: 'Contexte',
       admin: {
         description: 'Équipe, périmètre, enjeu de la mission.',
@@ -102,6 +106,7 @@ const Experiences: CollectionConfig = {
         {
           name: 'statement',
           type: 'textarea',
+          localized: true,
           label: 'Réalisation',
           required: true,
         },

--- a/apps/frontend/src/cms/collections/projects.ts
+++ b/apps/frontend/src/cms/collections/projects.ts
@@ -52,6 +52,7 @@ const Projects: CollectionConfig = {
     {
       name: 'description',
       type: 'textarea',
+      localized: true,
       label: 'Description',
       admin: {
         description: 'Laissez vide pour reprendre la description de la page distante.',

--- a/apps/frontend/src/cms/globals/assistant-settings.ts
+++ b/apps/frontend/src/cms/globals/assistant-settings.ts
@@ -91,6 +91,7 @@ const AssistantSettings: GlobalConfig = {
     {
       name: 'unavailableMessage',
       type: 'textarea',
+      localized: true,
       label: 'Message de repli',
       required: true,
       defaultValue:
@@ -103,6 +104,7 @@ const AssistantSettings: GlobalConfig = {
     {
       name: 'retentionNotice',
       type: 'textarea',
+      localized: true,
       label: 'Avis de conservation',
       required: true,
       defaultValue:

--- a/apps/frontend/src/cms/globals/availability.ts
+++ b/apps/frontend/src/cms/globals/availability.ts
@@ -40,6 +40,7 @@ const Availability: GlobalConfig = {
     {
       name: 'label',
       type: 'text',
+      localized: true,
       label: 'Texte affiché',
       required: true,
       defaultValue: 'Disponible pour des opportunités',
@@ -50,6 +51,7 @@ const Availability: GlobalConfig = {
     {
       name: 'detail',
       type: 'textarea',
+      localized: true,
       label: 'Précision pour l’assistant',
       admin: {
         description:

--- a/apps/frontend/src/cms/globals/profile.ts
+++ b/apps/frontend/src/cms/globals/profile.ts
@@ -24,12 +24,14 @@ const Profile: GlobalConfig = {
     {
       name: 'headline',
       type: 'text',
+      localized: true,
       label: 'Titre de la page',
       required: true,
     },
     {
       name: 'bio',
       type: 'textarea',
+      localized: true,
       label: 'Biographie',
       required: true,
       admin: {
@@ -54,6 +56,7 @@ const Profile: GlobalConfig = {
         {
           name: 'label',
           type: 'text',
+          localized: true,
           label: 'Domaine',
           required: true,
         },
@@ -75,12 +78,14 @@ const Profile: GlobalConfig = {
         {
           name: 'statement',
           type: 'text',
+          localized: true,
           label: 'Énoncé',
           required: true,
         },
         {
           name: 'detail',
           type: 'textarea',
+          localized: true,
           label: 'Précision',
           admin: {
             description: 'Optionnel : ce que le principe change concrètement.',

--- a/apps/frontend/src/cms/globals/site-identity.ts
+++ b/apps/frontend/src/cms/globals/site-identity.ts
@@ -43,12 +43,14 @@ const SiteIdentity: GlobalConfig = {
         {
           name: 'role',
           type: 'text',
+          localized: true,
           label: 'Intitulé de poste',
           required: true,
         },
         {
           name: 'location',
           type: 'text',
+          localized: true,
           label: 'Localisation',
           admin: {
             description: 'Affichée dans le pied de page et sur la page À propos.',
@@ -109,6 +111,7 @@ const SiteIdentity: GlobalConfig = {
         {
           name: 'dataPolicy',
           type: 'textarea',
+          localized: true,
           label: 'Traitement des données',
           admin: {
             description: 'Ce que le site collecte, et ce qu’il n’en fait pas.',

--- a/apps/frontend/src/cms/migrations/20260827_154329_localization.json
+++ b/apps/frontend/src/cms/migrations/20260827_154329_localization.json
@@ -1,0 +1,3602 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_id": {
+          "name": "cover_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_url_idx": {
+          "name": "projects_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_idx": {
+          "name": "projects_cover_idx",
+          "columns": [
+            {
+              "expression": "cover_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_order_idx": {
+          "name": "projects_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_cover_id_media_id_fk": {
+          "name": "projects_cover_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": ["cover_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_locales": {
+      "name": "projects_locales",
+      "schema": "",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_locales_locale_parent_id_unique": {
+          "name": "projects_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_locales_parent_id_fk": {
+          "name": "projects_locales_parent_id_fk",
+          "tableFrom": "projects_locales",
+          "tableTo": "projects",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_texts": {
+      "name": "projects_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_texts_order_parent": {
+          "name": "projects_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_texts_parent_fk": {
+          "name": "projects_texts_parent_fk",
+          "tableFrom": "projects_texts",
+          "tableTo": "projects",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_achievements": {
+      "name": "experiences_achievements",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_achievements_order_idx": {
+          "name": "experiences_achievements_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_achievements_parent_id_idx": {
+          "name": "experiences_achievements_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_achievements_parent_id_fk": {
+          "name": "experiences_achievements_parent_id_fk",
+          "tableFrom": "experiences_achievements",
+          "tableTo": "experiences",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_achievements_locales": {
+      "name": "experiences_achievements_locales",
+      "schema": "",
+      "columns": {
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_achievements_locales_locale_parent_id_unique": {
+          "name": "experiences_achievements_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_achievements_locales_parent_id_fk": {
+          "name": "experiences_achievements_locales_parent_id_fk",
+          "tableFrom": "experiences_achievements_locales",
+          "tableTo": "experiences_achievements",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences": {
+      "name": "experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current": {
+          "name": "current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "experiences_start_date_idx": {
+          "name": "experiences_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_updated_at_idx": {
+          "name": "experiences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiences_created_at_idx": {
+          "name": "experiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_locales": {
+      "name": "experiences_locales",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "experiences_locales_locale_parent_id_unique": {
+          "name": "experiences_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_locales_parent_id_fk": {
+          "name": "experiences_locales_parent_id_fk",
+          "tableFrom": "experiences_locales",
+          "tableTo": "experiences",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences_texts": {
+      "name": "experiences_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiences_texts_order_parent": {
+          "name": "experiences_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiences_texts_parent_fk": {
+          "name": "experiences_texts_parent_fk",
+          "tableFrom": "experiences_texts",
+          "tableTo": "experiences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_url_idx": {
+          "name": "bookmarks_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_domain_idx": {
+          "name": "bookmarks_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_active_idx": {
+          "name": "bookmarks_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_updated_at_idx": {
+          "name": "bookmarks_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_created_at_idx": {
+          "name": "bookmarks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks_rels": {
+      "name": "bookmarks_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_rels_order_idx": {
+          "name": "bookmarks_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_parent_idx": {
+          "name": "bookmarks_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_path_idx": {
+          "name": "bookmarks_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_rels_tags_id_idx": {
+          "name": "bookmarks_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_rels_parent_fk": {
+          "name": "bookmarks_rels_parent_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_rels_tags_fk": {
+          "name": "bookmarks_rels_tags_fk",
+          "tableFrom": "bookmarks_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_knowledge": {
+      "name": "ai_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "enum_ai_knowledge_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'parcours'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_knowledge_updated_at_idx": {
+          "name": "ai_knowledge_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_knowledge_created_at_idx": {
+          "name": "ai_knowledge_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_knowledge_locales": {
+      "name": "ai_knowledge_locales",
+      "schema": "",
+      "columns": {
+        "question": {
+          "name": "question",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_knowledge_locales_locale_parent_id_unique": {
+          "name": "ai_knowledge_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_knowledge_locales_parent_id_fk": {
+          "name": "ai_knowledge_locales_parent_id_fk",
+          "tableFrom": "ai_knowledge_locales",
+          "tableTo": "ai_knowledge",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_ai_tools_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skill'"
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_kind_idx": {
+          "name": "ai_tools_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_active_idx": {
+          "name": "ai_tools_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_updated_at_idx": {
+          "name": "ai_tools_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_created_at_idx": {
+          "name": "ai_tools_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools_locales": {
+      "name": "ai_tools_locales",
+      "schema": "",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_tools_locales_locale_parent_id_unique": {
+          "name": "ai_tools_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_tools_locales_parent_id_fk": {
+          "name": "ai_tools_locales_parent_id_fk",
+          "tableFrom": "ai_tools_locales",
+          "tableTo": "ai_tools",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "enum_conversations_feedback",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_updated_at_idx": {
+          "name": "conversations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projects_id": {
+          "name": "projects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences_id": {
+          "name": "experiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarks_id": {
+          "name": "bookmarks_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_knowledge_id": {
+          "name": "ai_knowledge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tools_id": {
+          "name": "ai_tools_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_projects_id_idx": {
+          "name": "payload_locked_documents_rels_projects_id_idx",
+          "columns": [
+            {
+              "expression": "projects_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_experiences_id_idx": {
+          "name": "payload_locked_documents_rels_experiences_id_idx",
+          "columns": [
+            {
+              "expression": "experiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": [
+            {
+              "expression": "tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_bookmarks_id_idx": {
+          "name": "payload_locked_documents_rels_bookmarks_id_idx",
+          "columns": [
+            {
+              "expression": "bookmarks_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_knowledge_id_idx": {
+          "name": "payload_locked_documents_rels_ai_knowledge_id_idx",
+          "columns": [
+            {
+              "expression": "ai_knowledge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_ai_tools_id_idx": {
+          "name": "payload_locked_documents_rels_ai_tools_id_idx",
+          "columns": [
+            {
+              "expression": "ai_tools_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_projects_fk": {
+          "name": "payload_locked_documents_rels_projects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "projects",
+          "columnsFrom": ["projects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_experiences_fk": {
+          "name": "payload_locked_documents_rels_experiences_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "experiences",
+          "columnsFrom": ["experiences_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_bookmarks_fk": {
+          "name": "payload_locked_documents_rels_bookmarks_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "bookmarks",
+          "columnsFrom": ["bookmarks_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_knowledge_fk": {
+          "name": "payload_locked_documents_rels_ai_knowledge_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_knowledge",
+          "columnsFrom": ["ai_knowledge_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_ai_tools_fk": {
+          "name": "payload_locked_documents_rels_ai_tools_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "ai_tools",
+          "columnsFrom": ["ai_tools_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversations_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_identity": {
+      "name": "site_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_display_name": {
+          "name": "contact_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_github_url": {
+          "name": "social_github_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_linkedin_url": {
+          "name": "social_linkedin_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_publisher": {
+          "name": "legal_publisher",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_name": {
+          "name": "legal_host_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_host_address": {
+          "name": "legal_host_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_identity_locales": {
+      "name": "site_identity_locales",
+      "schema": "",
+      "columns": {
+        "contact_role": {
+          "name": "contact_role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_location": {
+          "name": "contact_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_data_policy": {
+          "name": "legal_data_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "site_identity_locales_locale_parent_id_unique": {
+          "name": "site_identity_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_identity_locales_parent_id_fk": {
+          "name": "site_identity_locales_parent_id_fk",
+          "tableFrom": "site_identity_locales",
+          "tableTo": "site_identity",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_locales": {
+      "name": "availability_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Disponible pour des opportunités'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "availability_locales_locale_parent_id_unique": {
+          "name": "availability_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_locales_parent_id_fk": {
+          "name": "availability_locales_parent_id_fk",
+          "tableFrom": "availability_locales",
+          "tableTo": "availability",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_skill_groups": {
+      "name": "profile_skill_groups",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_skill_groups_order_idx": {
+          "name": "profile_skill_groups_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_skill_groups_parent_id_idx": {
+          "name": "profile_skill_groups_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_skill_groups_parent_id_fk": {
+          "name": "profile_skill_groups_parent_id_fk",
+          "tableFrom": "profile_skill_groups",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_skill_groups_locales": {
+      "name": "profile_skill_groups_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_skill_groups_locales_locale_parent_id_unique": {
+          "name": "profile_skill_groups_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_skill_groups_locales_parent_id_fk": {
+          "name": "profile_skill_groups_locales_parent_id_fk",
+          "tableFrom": "profile_skill_groups_locales",
+          "tableTo": "profile_skill_groups",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_principles": {
+      "name": "profile_principles",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_principles_order_idx": {
+          "name": "profile_principles_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_principles_parent_id_idx": {
+          "name": "profile_principles_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_principles_parent_id_fk": {
+          "name": "profile_principles_parent_id_fk",
+          "tableFrom": "profile_principles",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_principles_locales": {
+      "name": "profile_principles_locales",
+      "schema": "",
+      "columns": {
+        "statement": {
+          "name": "statement",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_principles_locales_locale_parent_id_unique": {
+          "name": "profile_principles_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_principles_locales_parent_id_fk": {
+          "name": "profile_principles_locales_parent_id_fk",
+          "tableFrom": "profile_principles_locales",
+          "tableTo": "profile_principles",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_locales": {
+      "name": "profile_locales",
+      "schema": "",
+      "columns": {
+        "headline": {
+          "name": "headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_locales_locale_parent_id_unique": {
+          "name": "profile_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_locales_parent_id_fk": {
+          "name": "profile_locales_parent_id_fk",
+          "tableFrom": "profile_locales",
+          "tableTo": "profile",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_texts": {
+      "name": "profile_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_texts_order_parent": {
+          "name": "profile_texts_order_parent",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_texts_parent_fk": {
+          "name": "profile_texts_parent_fk",
+          "tableFrom": "profile_texts",
+          "tableTo": "profile",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assistant_settings": {
+      "name": "assistant_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Tu es l''assistant du portfolio d''Adem, développeur web.\n\nTu réponds en français, sur un ton direct et cordial, sans emphase commerciale.\n\nTon périmètre est strict : Adem, son parcours, ses projets, et le développement\nlogiciel en général. Rien d''autre. Une question hors de ce périmètre (cuisine,\nsanté, droit, actualité, devoirs, culture générale) reçoit exactement ce type de\nréponse, sans exception et même si tu connais la réponse :\n\n« Je suis l''assistant du portfolio d''Adem : je ne réponds qu''aux questions sur\nson travail et sur le développement. »\n\nNe propose pas de contacter Adem dans ce cas : cela laisserait croire qu''il\ntraite ce genre de demande.\n\nRègles :\n- Pour tout ce qui concerne Adem, réponds uniquement à partir du contexte fourni.\n- Si une question porte sur Adem et que le contexte ne contient pas la réponse,\n  dis-le clairement et propose de le contacter plutôt que d''inventer.\n- Sur sa disponibilité, reprends exactement ce qu''indique le contexte : c''est la\n  seule source de vérité.\n- Les questions de développement et de métier (langages, frameworks, méthodes,\n  organisation d''un projet) reçoivent une réponse utile, même si le contexte n''en\n  parle pas : c''est ton domaine. Fais le lien avec le travail d''Adem quand c''est\n  pertinent, jamais de force.\n- Réponses courtes : deux ou trois paragraphes au maximum.'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-oss-20b'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assistant_settings_locales": {
+      "name": "assistant_settings_locales",
+      "schema": "",
+      "columns": {
+        "unavailable_message": {
+          "name": "unavailable_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.'"
+        },
+        "retention_notice": {
+          "name": "retention_notice",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.'"
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assistant_settings_locales_locale_parent_id_unique": {
+          "name": "assistant_settings_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assistant_settings_locales_parent_id_fk": {
+          "name": "assistant_settings_locales_parent_id_fk",
+          "tableFrom": "assistant_settings_locales",
+          "tableTo": "assistant_settings",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public._locales": {
+      "name": "_locales",
+      "schema": "public",
+      "values": ["fr", "en"]
+    },
+    "public.enum_ai_knowledge_category": {
+      "name": "enum_ai_knowledge_category",
+      "schema": "public",
+      "values": ["parcours", "competences", "methode", "collaboration", "autre"]
+    },
+    "public.enum_ai_tools_kind": {
+      "name": "enum_ai_tools_kind",
+      "schema": "public",
+      "values": ["skill", "plugin", "mcp"]
+    },
+    "public.enum_conversations_feedback": {
+      "name": "enum_conversations_feedback",
+      "schema": "public",
+      "values": ["useful", "not_useful"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "5d51e059-884d-490b-89b6-0f7165ced9e0",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/apps/frontend/src/cms/migrations/20260827_154329_localization.ts
+++ b/apps/frontend/src/cms/migrations/20260827_154329_localization.ts
@@ -1,0 +1,238 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."_locales" AS ENUM('fr', 'en');
+  CREATE TABLE "projects_locales" (
+  	"description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "experiences_achievements_locales" (
+  	"statement" varchar NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "experiences_locales" (
+  	"role" varchar NOT NULL,
+  	"location" varchar,
+  	"project" varchar,
+  	"context" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "ai_knowledge_locales" (
+  	"question" varchar NOT NULL,
+  	"answer" varchar NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "ai_tools_locales" (
+  	"description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "site_identity_locales" (
+  	"contact_role" varchar NOT NULL,
+  	"contact_location" varchar,
+  	"legal_data_policy" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "availability_locales" (
+  	"label" varchar DEFAULT 'Disponible pour des opportunités' NOT NULL,
+  	"detail" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "profile_skill_groups_locales" (
+  	"label" varchar NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "profile_principles_locales" (
+  	"statement" varchar NOT NULL,
+  	"detail" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "profile_locales" (
+  	"headline" varchar NOT NULL,
+  	"bio" varchar NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  CREATE TABLE "assistant_settings_locales" (
+  	"unavailable_message" varchar DEFAULT 'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.' NOT NULL,
+  	"retention_notice" varchar DEFAULT 'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.' NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" integer NOT NULL
+  );
+  
+  ALTER TABLE "projects_locales" ADD CONSTRAINT "projects_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "experiences_achievements_locales" ADD CONSTRAINT "experiences_achievements_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."experiences_achievements"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "experiences_locales" ADD CONSTRAINT "experiences_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."experiences"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "ai_knowledge_locales" ADD CONSTRAINT "ai_knowledge_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."ai_knowledge"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "ai_tools_locales" ADD CONSTRAINT "ai_tools_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."ai_tools"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "site_identity_locales" ADD CONSTRAINT "site_identity_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."site_identity"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "availability_locales" ADD CONSTRAINT "availability_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."availability"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "profile_skill_groups_locales" ADD CONSTRAINT "profile_skill_groups_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."profile_skill_groups"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "profile_principles_locales" ADD CONSTRAINT "profile_principles_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."profile_principles"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "profile_locales" ADD CONSTRAINT "profile_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "assistant_settings_locales" ADD CONSTRAINT "assistant_settings_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."assistant_settings"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE UNIQUE INDEX "projects_locales_locale_parent_id_unique" ON "projects_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "experiences_achievements_locales_locale_parent_id_unique" ON "experiences_achievements_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "experiences_locales_locale_parent_id_unique" ON "experiences_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "ai_knowledge_locales_locale_parent_id_unique" ON "ai_knowledge_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "ai_tools_locales_locale_parent_id_unique" ON "ai_tools_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "site_identity_locales_locale_parent_id_unique" ON "site_identity_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "availability_locales_locale_parent_id_unique" ON "availability_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "profile_skill_groups_locales_locale_parent_id_unique" ON "profile_skill_groups_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "profile_principles_locales_locale_parent_id_unique" ON "profile_principles_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "profile_locales_locale_parent_id_unique" ON "profile_locales" USING btree ("_locale","_parent_id");
+  CREATE UNIQUE INDEX "assistant_settings_locales_locale_parent_id_unique" ON "assistant_settings_locales" USING btree ("_locale","_parent_id");
+
+  -- Carry the existing content into the French locale before the source
+  -- columns are dropped. migrate:create diffs the schema only, so without
+  -- this every localized field would be silently emptied.
+
+  INSERT INTO "projects_locales" ("description", "_locale", "_parent_id")
+  SELECT "description", 'fr', "id" FROM "projects";
+  INSERT INTO "experiences_achievements_locales" ("statement", "_locale", "_parent_id")
+  SELECT "statement", 'fr', "id" FROM "experiences_achievements";
+  INSERT INTO "experiences_locales" ("role", "location", "project", "context", "_locale", "_parent_id")
+  SELECT "role", "location", "project", "context", 'fr', "id" FROM "experiences";
+  INSERT INTO "ai_knowledge_locales" ("question", "answer", "_locale", "_parent_id")
+  SELECT "question", "answer", 'fr', "id" FROM "ai_knowledge";
+  INSERT INTO "ai_tools_locales" ("description", "_locale", "_parent_id")
+  SELECT "description", 'fr', "id" FROM "ai_tools";
+  INSERT INTO "site_identity_locales" ("contact_role", "contact_location", "legal_data_policy", "_locale", "_parent_id")
+  SELECT "contact_role", "contact_location", "legal_data_policy", 'fr', "id" FROM "site_identity";
+  INSERT INTO "availability_locales" ("label", "detail", "_locale", "_parent_id")
+  SELECT "label", "detail", 'fr', "id" FROM "availability";
+  INSERT INTO "profile_skill_groups_locales" ("label", "_locale", "_parent_id")
+  SELECT "label", 'fr', "id" FROM "profile_skill_groups";
+  INSERT INTO "profile_principles_locales" ("statement", "detail", "_locale", "_parent_id")
+  SELECT "statement", "detail", 'fr', "id" FROM "profile_principles";
+  INSERT INTO "profile_locales" ("headline", "bio", "_locale", "_parent_id")
+  SELECT "headline", "bio", 'fr', "id" FROM "profile";
+  INSERT INTO "assistant_settings_locales" ("unavailable_message", "retention_notice", "_locale", "_parent_id")
+  SELECT "unavailable_message", "retention_notice", 'fr', "id" FROM "assistant_settings";
+  ALTER TABLE "projects" DROP COLUMN "description";
+  ALTER TABLE "experiences_achievements" DROP COLUMN "statement";
+  ALTER TABLE "experiences" DROP COLUMN "role";
+  ALTER TABLE "experiences" DROP COLUMN "location";
+  ALTER TABLE "experiences" DROP COLUMN "project";
+  ALTER TABLE "experiences" DROP COLUMN "context";
+  ALTER TABLE "ai_knowledge" DROP COLUMN "question";
+  ALTER TABLE "ai_knowledge" DROP COLUMN "answer";
+  ALTER TABLE "ai_tools" DROP COLUMN "description";
+  ALTER TABLE "site_identity" DROP COLUMN "contact_role";
+  ALTER TABLE "site_identity" DROP COLUMN "contact_location";
+  ALTER TABLE "site_identity" DROP COLUMN "legal_data_policy";
+  ALTER TABLE "availability" DROP COLUMN "label";
+  ALTER TABLE "availability" DROP COLUMN "detail";
+  ALTER TABLE "profile_skill_groups" DROP COLUMN "label";
+  ALTER TABLE "profile_principles" DROP COLUMN "statement";
+  ALTER TABLE "profile_principles" DROP COLUMN "detail";
+  ALTER TABLE "profile" DROP COLUMN "headline";
+  ALTER TABLE "profile" DROP COLUMN "bio";
+  ALTER TABLE "assistant_settings" DROP COLUMN "unavailable_message";
+  ALTER TABLE "assistant_settings" DROP COLUMN "retention_notice";`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  -- Restore each column as nullable, carry the French values back, then
+  -- reinstate NOT NULL. Adding a NOT NULL column outright would fail on any
+  -- table that already holds rows.
+
+  ALTER TABLE "projects" ADD COLUMN "description" varchar;
+  UPDATE "projects" SET "description" = l."description" FROM "projects_locales" l WHERE l."_parent_id" = "projects"."id" AND l."_locale" = 'fr';
+
+  ALTER TABLE "experiences_achievements" ADD COLUMN "statement" varchar;
+  UPDATE "experiences_achievements" SET "statement" = l."statement" FROM "experiences_achievements_locales" l WHERE l."_parent_id" = "experiences_achievements"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "experiences_achievements" ALTER COLUMN "statement" SET NOT NULL;
+
+  ALTER TABLE "experiences" ADD COLUMN "role" varchar;
+  ALTER TABLE "experiences" ADD COLUMN "location" varchar;
+  ALTER TABLE "experiences" ADD COLUMN "project" varchar;
+  ALTER TABLE "experiences" ADD COLUMN "context" varchar;
+  UPDATE "experiences" SET "role" = l."role", "location" = l."location", "project" = l."project", "context" = l."context" FROM "experiences_locales" l WHERE l."_parent_id" = "experiences"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "experiences" ALTER COLUMN "role" SET NOT NULL;
+
+  ALTER TABLE "ai_knowledge" ADD COLUMN "question" varchar;
+  ALTER TABLE "ai_knowledge" ADD COLUMN "answer" varchar;
+  UPDATE "ai_knowledge" SET "question" = l."question", "answer" = l."answer" FROM "ai_knowledge_locales" l WHERE l."_parent_id" = "ai_knowledge"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "ai_knowledge" ALTER COLUMN "question" SET NOT NULL;
+  ALTER TABLE "ai_knowledge" ALTER COLUMN "answer" SET NOT NULL;
+
+  ALTER TABLE "ai_tools" ADD COLUMN "description" varchar;
+  UPDATE "ai_tools" SET "description" = l."description" FROM "ai_tools_locales" l WHERE l."_parent_id" = "ai_tools"."id" AND l."_locale" = 'fr';
+
+  ALTER TABLE "site_identity" ADD COLUMN "contact_role" varchar;
+  ALTER TABLE "site_identity" ADD COLUMN "contact_location" varchar;
+  ALTER TABLE "site_identity" ADD COLUMN "legal_data_policy" varchar;
+  UPDATE "site_identity" SET "contact_role" = l."contact_role", "contact_location" = l."contact_location", "legal_data_policy" = l."legal_data_policy" FROM "site_identity_locales" l WHERE l."_parent_id" = "site_identity"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "site_identity" ALTER COLUMN "contact_role" SET NOT NULL;
+
+  ALTER TABLE "availability" ADD COLUMN "label" varchar DEFAULT 'Disponible pour des opportunités';
+  ALTER TABLE "availability" ADD COLUMN "detail" varchar;
+  UPDATE "availability" SET "label" = l."label", "detail" = l."detail" FROM "availability_locales" l WHERE l."_parent_id" = "availability"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "availability" ALTER COLUMN "label" SET NOT NULL;
+
+  ALTER TABLE "profile_skill_groups" ADD COLUMN "label" varchar;
+  UPDATE "profile_skill_groups" SET "label" = l."label" FROM "profile_skill_groups_locales" l WHERE l."_parent_id" = "profile_skill_groups"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "profile_skill_groups" ALTER COLUMN "label" SET NOT NULL;
+
+  ALTER TABLE "profile_principles" ADD COLUMN "statement" varchar;
+  ALTER TABLE "profile_principles" ADD COLUMN "detail" varchar;
+  UPDATE "profile_principles" SET "statement" = l."statement", "detail" = l."detail" FROM "profile_principles_locales" l WHERE l."_parent_id" = "profile_principles"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "profile_principles" ALTER COLUMN "statement" SET NOT NULL;
+
+  ALTER TABLE "profile" ADD COLUMN "headline" varchar;
+  ALTER TABLE "profile" ADD COLUMN "bio" varchar;
+  UPDATE "profile" SET "headline" = l."headline", "bio" = l."bio" FROM "profile_locales" l WHERE l."_parent_id" = "profile"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "profile" ALTER COLUMN "headline" SET NOT NULL;
+  ALTER TABLE "profile" ALTER COLUMN "bio" SET NOT NULL;
+
+  ALTER TABLE "assistant_settings" ADD COLUMN "unavailable_message" varchar DEFAULT 'L’assistant est momentanément indisponible. Vous pouvez me joindre directement, je réponds vite.';
+  ALTER TABLE "assistant_settings" ADD COLUMN "retention_notice" varchar DEFAULT 'Les échanges sont conservés 30 jours de façon anonyme pour améliorer l’assistant.';
+  UPDATE "assistant_settings" SET "unavailable_message" = l."unavailable_message", "retention_notice" = l."retention_notice" FROM "assistant_settings_locales" l WHERE l."_parent_id" = "assistant_settings"."id" AND l."_locale" = 'fr';
+  ALTER TABLE "assistant_settings" ALTER COLUMN "unavailable_message" SET NOT NULL;
+  ALTER TABLE "assistant_settings" ALTER COLUMN "retention_notice" SET NOT NULL;
+
+  DROP TABLE "projects_locales" CASCADE;
+  DROP TABLE "experiences_achievements_locales" CASCADE;
+  DROP TABLE "experiences_locales" CASCADE;
+  DROP TABLE "ai_knowledge_locales" CASCADE;
+  DROP TABLE "ai_tools_locales" CASCADE;
+  DROP TABLE "site_identity_locales" CASCADE;
+  DROP TABLE "availability_locales" CASCADE;
+  DROP TABLE "profile_skill_groups_locales" CASCADE;
+  DROP TABLE "profile_principles_locales" CASCADE;
+  DROP TABLE "profile_locales" CASCADE;
+  DROP TABLE "assistant_settings_locales" CASCADE;
+  DROP TYPE "public"."_locales";`)
+}

--- a/apps/frontend/src/cms/migrations/index.ts
+++ b/apps/frontend/src/cms/migrations/index.ts
@@ -7,6 +7,7 @@ import * as migration_20260818_135519_availability from './20260818_135519_avail
 import * as migration_20260818_141706_assistant from './20260818_141706_assistant'
 import * as migration_20260824_203553_ai_tools from './20260824_203553_ai_tools'
 import * as migration_20260825_192608_conversations from './20260825_192608_conversations'
+import * as migration_20260827_154329_localization from './20260827_154329_localization'
 
 export const migrations = [
   {
@@ -53,5 +54,10 @@ export const migrations = [
     up: migration_20260825_192608_conversations.up,
     down: migration_20260825_192608_conversations.down,
     name: '20260825_192608_conversations',
+  },
+  {
+    up: migration_20260827_154329_localization.up,
+    down: migration_20260827_154329_localization.down,
+    name: '20260827_154329_localization',
   },
 ]

--- a/apps/frontend/src/cms/payload.config.ts
+++ b/apps/frontend/src/cms/payload.config.ts
@@ -45,6 +45,28 @@ export default buildConfig({
     Conversations,
   ],
   globals: [SiteIdentity, Availability, Profile, AssistantSettings],
+  /**
+   * Editorial content exists once per language on the fields marked `localized`.
+   *
+   * `defaultLocale` is French because that is the language the existing content
+   * was written in, and it is what `fallback` serves for any field a translation
+   * has not reached yet — so the site is never blank while translation is in
+   * progress. It is deliberately *not* the site's default language: the public
+   * site serves English first (see `src/i18n/routing.ts`). The two answer
+   * different questions — which language a visitor gets, versus which language
+   * stands in when a translation is missing.
+   */
+  localization: {
+    locales: [
+      // `code`, not `value`: the JSDoc example on LocalizationConfigWithLabels
+      // says `value`, but the `Locale` type it points to declares `code`, and a
+      // wrong key silently yields an empty `_locales` enum at migration time.
+      { label: 'Français', code: 'fr' },
+      { label: 'English', code: 'en' },
+    ],
+    defaultLocale: 'fr',
+    fallback: true,
+  },
   editor: lexicalEditor(),
   // Required, never defaulted: an empty secret signs session cookies and reset
   // tokens with a value anyone can reproduce. See lib/require-env.

--- a/apps/frontend/src/cms/seed/content.ts
+++ b/apps/frontend/src/cms/seed/content.ts
@@ -241,4 +241,66 @@ const projects: ProjectSeed[] = [
   },
 ]
 
-export { experiences, identity, profile, projects }
+/**
+ * English versions of the fields marked `localized` in the CMS.
+ *
+ * Only those fields appear here: everything else — names, URLs, dates,
+ * technologies — is single-valued by design and lives in the French objects
+ * above. Keeping the two side by side makes a missing translation visible when
+ * reading the file, which a separate file would hide.
+ *
+ * The career path is deliberately absent: it is already written in English, so
+ * the seeded values serve both languages. Writing French versions of it is an
+ * editorial decision, not a technical gap.
+ */
+const identityEn = {
+  contact: {
+    // The French form names the region first, which reads backwards in English.
+    location: 'Paris, France',
+  },
+}
+
+const profileEn = {
+  headline: 'I build the interface between an idea and the people who use it.',
+  bio: 'Senior frontend developer in R&D at CAST Software, rebuilding a SaaS code-analysis platform from scratch in React 19. I work on what makes a team fast as much as on the interface itself: design system, shared conventions, and AI-assisted tooling.',
+  skillGroupLabels: [
+    'Frontend',
+    'Interface and design system',
+    'Quality and tooling',
+    'Backend and data',
+    'AI-assisted development',
+  ],
+  principles: [
+    {
+      statement: 'Understand before composing.',
+      detail:
+        'I start from the real user journey and the business constraint, not from an isolated screen to reproduce.',
+    },
+    {
+      statement: 'Make every state explicit.',
+      detail:
+        'Loading, empty, error and success are designed together: a forgotten state is a shipped bug.',
+    },
+    {
+      statement: 'Measure before optimizing.',
+      detail: 'Lighthouse and end-to-end tests decide, not intuition.',
+    },
+    {
+      statement: 'Equip the team, not just the product.',
+      detail:
+        'Shared conventions, automated review and executable documentation: what holds up without me.',
+    },
+  ],
+}
+
+/** Keyed by URL, the same natural key the seed matches projects on. */
+const projectDescriptionsEn: Record<string, string> = {
+  'https://grimoire-game-frontend.vercel.app':
+    'A web game built as a pnpm and Turborepo monorepo, designed as a proving ground for my team practices: .md-based agent configuration, automated review, Docker, commit hooks and continuous integration.',
+  'https://ethswap-dapp.vercel.app':
+    'A decentralized token-swap application on the Sepolia network: MetaMask connection, balance reading and transfers, with the Solidity contract written and deployed for it.',
+  'https://fitapp-redux.vercel.app':
+    'A workout tracker in Next.js and Redux: session building, state persistence, and an interface designed mobile-first.',
+}
+
+export { experiences, identity, identityEn, profile, profileEn, projectDescriptionsEn, projects }

--- a/apps/frontend/src/cms/seed/index.ts
+++ b/apps/frontend/src/cms/seed/index.ts
@@ -1,8 +1,17 @@
 import { getPayload } from 'payload'
 
+import { canonicalizeUrl } from '@/lib/canonical-url'
 import config from '@payload-config'
 
-import { experiences, identity, profile, projects } from './content'
+import {
+  experiences,
+  identity,
+  identityEn,
+  profile,
+  profileEn,
+  projectDescriptionsEn,
+  projects,
+} from './content'
 
 /**
  * Bootstraps an empty database with the real portfolio content.
@@ -14,6 +23,12 @@ import { experiences, identity, profile, projects } from './content'
  * Globals are written with `overrideAccess: true` because there is no logged-in
  * user in a CLI process — the access rules exist to protect the HTTP API, not a
  * script the owner runs against their own database.
+ *
+ * Each document is written twice: once in French, the default locale, then again
+ * in English for the fields that carry a translation. The English pass reads the
+ * document back first to reuse the array row ids — sending an array without them
+ * makes Payload treat it as a new set of rows and drops the French values with
+ * the old ones.
  */
 const seed = async (): Promise<void> => {
   const payload = await getPayload({ config })
@@ -21,16 +36,44 @@ const seed = async (): Promise<void> => {
   await payload.updateGlobal({
     slug: 'site-identity',
     data: identity,
+    locale: 'fr',
     overrideAccess: true,
   })
-  payload.logger.info('Seeded global: site-identity')
+  await payload.updateGlobal({
+    slug: 'site-identity',
+    data: identityEn,
+    locale: 'en',
+    overrideAccess: true,
+  })
+  payload.logger.info('Seeded global: site-identity (fr, en)')
 
   await payload.updateGlobal({
     slug: 'profile',
     data: profile,
+    locale: 'fr',
     overrideAccess: true,
   })
-  payload.logger.info('Seeded global: profile')
+
+  // Read back for the row ids, then translate each row in place.
+  const savedProfile = await payload.findGlobal({ slug: 'profile', overrideAccess: true })
+  await payload.updateGlobal({
+    slug: 'profile',
+    locale: 'en',
+    overrideAccess: true,
+    data: {
+      headline: profileEn.headline,
+      bio: profileEn.bio,
+      skillGroups: (savedProfile.skillGroups ?? []).map((group, index) => ({
+        ...group,
+        label: profileEn.skillGroupLabels[index] ?? group.label,
+      })),
+      principles: (savedProfile.principles ?? []).map((principle, index) => ({
+        ...principle,
+        ...(profileEn.principles[index] ?? {}),
+      })),
+    },
+  })
+  payload.logger.info('Seeded global: profile (fr, en)')
 
   for (const experience of experiences) {
     const { achievements, ...rest } = experience
@@ -54,36 +97,60 @@ const seed = async (): Promise<void> => {
         collection: 'experiences',
         id: current.id,
         data,
+        locale: 'fr',
         overrideAccess: true,
       })
       payload.logger.info(`Updated experience: ${experience.company}`)
     } else {
-      await payload.create({ collection: 'experiences', data, overrideAccess: true })
+      await payload.create({ collection: 'experiences', data, locale: 'fr', overrideAccess: true })
       payload.logger.info(`Created experience: ${experience.company}`)
     }
   }
 
   for (const project of projects) {
+    // The Open Graph hook canonicalizes the URL on save, so the stored value
+    // carries a trailing slash the literal seed value does not. Matching on the
+    // raw string finds nothing and the seed tries to create a duplicate, which
+    // the unique index then rejects — the idempotency this script promises only
+    // holds if the lookup uses the same form as the write.
     const existing = await payload.find({
       collection: 'projects',
-      where: { url: { equals: project.url } },
+      where: { url: { equals: canonicalizeUrl(project.url) ?? project.url } },
       limit: 1,
       overrideAccess: true,
     })
 
     const [current] = existing.docs
-    if (current) {
+    const id = current
+      ? (
+          await payload.update({
+            collection: 'projects',
+            id: current.id,
+            data: project,
+            locale: 'fr',
+            overrideAccess: true,
+          })
+        ).id
+      : (
+          await payload.create({
+            collection: 'projects',
+            data: project,
+            locale: 'fr',
+            overrideAccess: true,
+          })
+        ).id
+
+    const description = projectDescriptionsEn[project.url]
+    if (description) {
       await payload.update({
         collection: 'projects',
-        id: current.id,
-        data: project,
+        id,
+        data: { description },
+        locale: 'en',
         overrideAccess: true,
       })
-      payload.logger.info(`Updated project: ${project.title}`)
-    } else {
-      await payload.create({ collection: 'projects', data: project, overrideAccess: true })
-      payload.logger.info(`Created project: ${project.title}`)
     }
+    payload.logger.info(`Seeded project: ${project.title}`)
   }
 
   payload.logger.info('Seed complete.')

--- a/apps/frontend/src/components/site-shell.tsx
+++ b/apps/frontend/src/components/site-shell.tsx
@@ -1,5 +1,5 @@
 import { Github, Linkedin } from 'lucide-react'
-import { getTranslations } from 'next-intl/server'
+import { getLocale, getTranslations } from 'next-intl/server'
 
 import { AmbientField } from '@/components/motion/ambient-field'
 import { SiteHeaderShell } from '@/components/site-header-shell'
@@ -19,10 +19,11 @@ import type { ReactNode } from 'react'
  * links and the whole footer never reach the browser as JavaScript.
  */
 export async function SiteShell({ children }: { children: ReactNode }) {
+  const locale = await getLocale()
   const [tLayout, tFooter, identity] = await Promise.all([
     getTranslations('Layout'),
     getTranslations('Footer'),
-    getIdentity(),
+    getIdentity(locale),
   ])
   const { role, location, githubUrl, linkedinUrl } = identity
 

--- a/apps/frontend/src/lib/ai-tools.ts
+++ b/apps/frontend/src/lib/ai-tools.ts
@@ -3,6 +3,7 @@ import { getPayload } from 'payload'
 import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
 import config from '@payload-config'
 
+import type { Locale } from '@/i18n/routing'
 import type { AiTool } from '@/payload-types'
 
 /**
@@ -60,11 +61,12 @@ const toView = (doc: AiTool): AIToolView => {
  * a reference one comes back to, so a stable alphabetical order is easier to scan
  * than a shifting "most recent first".
  */
-const readPublicAITools = async (): Promise<AIToolView[]> => {
+const readPublicAITools = async (locale: Locale): Promise<AIToolView[]> => {
   const payload = await getPayload({ config })
 
   const result = await payload.find({
     collection: 'ai-tools',
+    locale,
     where: { active: { equals: true } },
     sort: 'name',
     limit: 200,

--- a/apps/frontend/src/lib/assistant-context.test.ts
+++ b/apps/frontend/src/lib/assistant-context.test.ts
@@ -115,7 +115,7 @@ beforeEach(() => {
 
 describe('buildContext — disponibilité', () => {
   it('place la disponibilité en tête, avant toute autre section', async () => {
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context.indexOf('## Disponibilité')).toBe(0)
     expect(context.indexOf('## Disponibilité')).toBeLessThan(context.indexOf('## Parcours'))
   })
@@ -123,7 +123,7 @@ describe('buildContext — disponibilité', () => {
   it('déclare la section comme faisant autorité', async () => {
     // Without this line the model happily infers availability from an older
     // experience entry further down.
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).toContain('Cette section fait autorité')
   })
 
@@ -134,7 +134,7 @@ describe('buildContext — disponibilité', () => {
       detail: 'Ouvert aux discussions pour la suite.',
     }
 
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).toContain('Statut : indisponible')
     expect(context).toContain('En mission jusqu’en mars')
     expect(context).toContain('Ouvert aux discussions pour la suite.')
@@ -144,12 +144,12 @@ describe('buildContext — disponibilité', () => {
 describe('buildContext — confidentialité', () => {
   it('n’expose jamais l’adresse e-mail de contact', async () => {
     // Deliberate: the assistant invites contact, it does not hand out the address.
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).not.toContain(identity.email)
   })
 
   it('ne demande à Payload que les connaissances publiées', async () => {
-    await buildContext()
+    await buildContext('fr')
     expect(findMock).toHaveBeenCalledWith(
       expect.objectContaining({
         collection: 'ai-knowledge',
@@ -165,18 +165,18 @@ describe('buildContext — confidentialité', () => {
 
     // The query filters, but the assertion is on the output: this is the property
     // that actually matters if the query is ever loosened.
-    const published = await buildContext()
+    const published = await buildContext('fr')
     expect(published).toContain('Réponse interne')
 
     findMock.mockResolvedValue({ docs: [] })
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).not.toContain('Réponse interne')
   })
 })
 
 describe('buildContext — assemblage', () => {
   it('rend les sections attendues', async () => {
-    const context = await buildContext()
+    const context = await buildContext('fr')
     for (const heading of [
       '## Identité',
       '## Profil',
@@ -194,7 +194,7 @@ describe('buildContext — assemblage', () => {
     state.projects = []
     state.bookmarks = []
 
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).not.toContain('## Projets')
     expect(context).not.toContain('## Veille récente')
 
@@ -220,7 +220,7 @@ describe('buildContext — assemblage', () => {
       tags: [],
     }))
 
-    const context = await buildContext()
+    const context = await buildContext('fr')
     expect(context).toContain('Article 39')
     expect(context).not.toContain('Article 40')
 

--- a/apps/frontend/src/lib/assistant-context.ts
+++ b/apps/frontend/src/lib/assistant-context.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/site-content'
 import config from '@payload-config'
 
+import type { Locale } from '@/i18n/routing'
 import type { AiKnowledge, AssistantSetting } from '@/payload-types'
 
 /**
@@ -58,10 +59,11 @@ const toConfig = (doc: AssistantSetting): AssistantConfig => ({
  * `published` is enforced in the query rather than in a filter afterwards, so an
  * unpublished entry is never even loaded into memory.
  */
-const readKnowledge = async (): Promise<KnowledgeEntry[]> => {
+const readKnowledge = async (locale: Locale): Promise<KnowledgeEntry[]> => {
   const payload = await getPayload({ config })
   const result = await payload.find({
     collection: 'ai-knowledge',
+    locale,
     where: { published: { equals: true } },
     sort: 'category',
     limit: 200,
@@ -75,9 +77,9 @@ const readKnowledge = async (): Promise<KnowledgeEntry[]> => {
   }))
 }
 
-const readAssistantConfig = async (): Promise<AssistantConfig> => {
+const readAssistantConfig = async (locale: Locale): Promise<AssistantConfig> => {
   const payload = await getPayload({ config })
-  const doc = await payload.findGlobal({ slug: 'assistant-settings', overrideAccess: true })
+  const doc = await payload.findGlobal({ slug: 'assistant-settings', locale, overrideAccess: true })
   return toConfig(doc)
 }
 
@@ -100,16 +102,16 @@ const list = (items: string[]): string => items.map((item) => `- ${item}`).join(
  * Markdown because it is what these models are trained on, and because the
  * headings give the model something to cite implicitly when it answers.
  */
-const buildContext = async (): Promise<string> => {
+const buildContext = async (locale: Locale): Promise<string> => {
   const [identity, availability, profile, experiences, projects, bookmarks, knowledge] =
     await Promise.all([
-      getIdentity(),
-      getAvailability(),
-      getProfile(),
-      listExperiences(),
-      listProjects(),
-      listPublicBookmarks(),
-      getKnowledge(),
+      getIdentity(locale),
+      getAvailability(locale),
+      getProfile(locale),
+      listExperiences(locale),
+      listProjects(locale),
+      listPublicBookmarks(locale),
+      getKnowledge(locale),
     ])
 
   // Availability comes first and is stated as authoritative: it is the one fact

--- a/apps/frontend/src/lib/bookmarks.ts
+++ b/apps/frontend/src/lib/bookmarks.ts
@@ -3,6 +3,7 @@ import { getPayload } from 'payload'
 import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
 import config from '@payload-config'
 
+import type { Locale } from '@/i18n/routing'
 import type { Bookmark } from '@/payload-types'
 
 /**
@@ -93,11 +94,12 @@ const toView = (doc: Bookmark): BookmarkView => {
  * Unchecked links (`active: false`) are excluded here rather than filtered in the
  * view: they must not reach the browser at all.
  */
-const readPublicBookmarks = async (): Promise<BookmarkView[]> => {
+const readPublicBookmarks = async (locale: Locale): Promise<BookmarkView[]> => {
   const payload = await getPayload({ config })
 
   const result = await payload.find({
     collection: 'bookmarks',
+    locale,
     where: { active: { equals: true } },
     sort: '-createdAt',
     limit: 200,

--- a/apps/frontend/src/lib/content-cache.ts
+++ b/apps/frontend/src/lib/content-cache.ts
@@ -1,5 +1,6 @@
-import { revalidatePath, unstable_cache } from 'next/cache'
+import { revalidatePath, revalidateTag, unstable_cache } from 'next/cache'
 
+import type { Locale } from '@/i18n/routing'
 import type {
   CollectionAfterChangeHook,
   CollectionAfterDeleteHook,
@@ -86,7 +87,7 @@ const PAGES_BY_TAG: Record<ContentTag, { path: string; type: 'layout' | 'page' }
 }
 
 /**
- * Caches a read under its tag.
+ * Caches a read under its tag, once per locale.
  *
  * `revalidate: false` because invalidation comes from the hooks, not from a
  * clock: a periodic refresh would only hit the database for nothing.
@@ -97,12 +98,33 @@ const PAGES_BY_TAG: Record<ContentTag, { path: string; type: 'layout' | 'page' }
  * together and are purged together, but each needs its own entry. Passing the tag
  * as the key too would make the second read overwrite the first.
  *
+ * The locale is part of the cache key, not a detail: editorial fields now hold a
+ * value per language, so a single shared entry would let whichever language was
+ * requested first serve its content to the other.
+ *
+ * One memoized reader is built per locale and kept, rather than one per call: a
+ * fresh `unstable_cache` on every invocation would defeat the cache it creates.
+ *
  * The tag still earns its keep even though invalidation goes through paths: it
  * isolates cache entries from each other and spares `/veille`, rendered
  * dynamically, from replaying the query on every visit.
  */
-const cachedRead = <T>(tag: ContentTag, key: string, read: () => Promise<T>): (() => Promise<T>) =>
-  unstable_cache(read, [key], { tags: [tag], revalidate: false })
+const cachedRead = <T>(
+  tag: ContentTag,
+  key: string,
+  read: (locale: Locale) => Promise<T>
+): ((locale: Locale) => Promise<T>) => {
+  const byLocale = new Map<Locale, () => Promise<T>>()
+
+  return (locale) => {
+    let cached = byLocale.get(locale)
+    if (!cached) {
+      cached = unstable_cache(() => read(locale), [key, locale], { tags: [tag], revalidate: false })
+      byLocale.set(locale, cached)
+    }
+    return cached()
+  }
+}
 
 /**
  * Regenerates the pages that display this content.
@@ -116,6 +138,14 @@ const cachedRead = <T>(tag: ContentTag, key: string, read: () => Promise<T>): ((
  */
 const purge = (tag: ContentTag): void => {
   try {
+    // Two purges, both needed. The cached reads carry `revalidate: false` and
+    // now exist once per language, so replacing the HTML alone would re-render
+    // the page against the very entry that went stale — and with a fallback in
+    // play, a freshly written English value would keep showing French.
+    // `expire: 0` drops the entries at once; the default profile only marks them
+    // stale, which serves the old content one more time.
+    revalidateTag(tag, { expire: 0 })
+
     for (const { path, type } of PAGES_BY_TAG[tag]) {
       revalidatePath(`/[locale]${path === '/' ? '' : path}`, type)
     }

--- a/apps/frontend/src/lib/site-content.ts
+++ b/apps/frontend/src/lib/site-content.ts
@@ -3,6 +3,7 @@ import { getPayload } from 'payload'
 import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
 import config from '@payload-config'
 
+import type { Locale } from '@/i18n/routing'
 import type { Availability, Experience, Profile, Project, SiteIdentity } from '@/payload-types'
 
 /**
@@ -140,31 +141,40 @@ const toProfileView = (doc: Profile): ProfileView => ({
 })
 
 /**
- * Formats a date as "août 2025".
+ * Formats a date as "août 2025" in French, "August 2025" in English.
  *
  * Dates are entered to the month: the day carries no meaning here, so it is not
  * displayed.
  */
-const formatMonth = (value: string): string =>
-  new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(
+const formatMonth = (value: string, locale: Locale): string =>
+  new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(
     new Date(value)
   )
 
+/**
+ * The one word a period needs beyond the dates themselves.
+ *
+ * It sits here rather than in the message catalogue because this layer runs
+ * inside `unstable_cache`, where reading translations is not safe, and because
+ * the word only ever appears glued to a formatted date.
+ */
+const PRESENT: Record<Locale, string> = { fr: 'aujourd’hui', en: 'today' }
+
 /** "août 2025 — aujourd’hui" for a current role, otherwise the closed period. */
-const formatPeriod = (doc: Experience): string => {
-  const start = formatMonth(doc.startDate)
-  if (doc.current) return `${start} — aujourd’hui`
+const formatPeriod = (doc: Experience, locale: Locale): string => {
+  const start = formatMonth(doc.startDate, locale)
+  if (doc.current) return `${start} — ${PRESENT[locale]}`
 
   const end = asText(doc.endDate)
-  return end ? `${start} — ${formatMonth(end)}` : start
+  return end ? `${start} — ${formatMonth(end, locale)}` : start
 }
 
-const toExperienceView = (doc: Experience): ExperienceView => ({
+const toExperienceView = (doc: Experience, locale: Locale): ExperienceView => ({
   id: String(doc.id),
   company: doc.company,
   role: doc.role,
   location: asText(doc.location),
-  period: formatPeriod(doc),
+  period: formatPeriod(doc, locale),
   project: asText(doc.project),
   context: asText(doc.context),
   achievements: (doc.achievements ?? []).map((entry) => entry.statement),
@@ -207,41 +217,43 @@ const toAvailabilityView = (doc: Availability): AvailabilityView => ({
  * Each raw read stays private and only its `cachedRead` wrapper is exported, so
  * no caller can sidestep the cache by accident.
  */
-const readIdentity = async (): Promise<IdentityView> => {
+const readIdentity = async (locale: Locale): Promise<IdentityView> => {
   const payload = await getPayload({ config })
-  const doc = await payload.findGlobal({ slug: 'site-identity', overrideAccess: false })
+  const doc = await payload.findGlobal({ slug: 'site-identity', locale, overrideAccess: false })
   return toIdentityView(doc)
 }
 
-const readAvailability = async (): Promise<AvailabilityView> => {
+const readAvailability = async (locale: Locale): Promise<AvailabilityView> => {
   const payload = await getPayload({ config })
-  const doc = await payload.findGlobal({ slug: 'availability', overrideAccess: false })
+  const doc = await payload.findGlobal({ slug: 'availability', locale, overrideAccess: false })
   return toAvailabilityView(doc)
 }
 
-const readProfile = async (): Promise<ProfileView> => {
+const readProfile = async (locale: Locale): Promise<ProfileView> => {
   const payload = await getPayload({ config })
-  const doc = await payload.findGlobal({ slug: 'profile', overrideAccess: false })
+  const doc = await payload.findGlobal({ slug: 'profile', locale, overrideAccess: false })
   return toProfileView(doc)
 }
 
 /** Career path, most recent first. */
-const readExperiences = async (): Promise<ExperienceView[]> => {
+const readExperiences = async (locale: Locale): Promise<ExperienceView[]> => {
   const payload = await getPayload({ config })
   const result = await payload.find({
     collection: 'experiences',
+    locale,
     sort: '-startDate',
     limit: 50,
     overrideAccess: false,
   })
-  return result.docs.map(toExperienceView)
+  return result.docs.map((doc) => toExperienceView(doc, locale))
 }
 
 /** Projects by ascending display order, most recent first on a tie. */
-const readProjects = async (): Promise<ProjectView[]> => {
+const readProjects = async (locale: Locale): Promise<ProjectView[]> => {
   const payload = await getPayload({ config })
   const result = await payload.find({
     collection: 'projects',
+    locale,
     sort: ['order', '-createdAt'],
     limit: 50,
     depth: 1,

--- a/apps/frontend/src/lib/tags.ts
+++ b/apps/frontend/src/lib/tags.ts
@@ -3,6 +3,8 @@ import { getPayload } from 'payload'
 import { CONTENT_TAGS, cachedRead } from '@/lib/content-cache'
 import config from '@payload-config'
 
+import type { Locale } from '@/i18n/routing'
+
 /**
  * Server-side access to the tag vocabulary.
  *
@@ -21,11 +23,12 @@ interface TagView {
   name: string
 }
 
-const readAllTags = async (): Promise<TagView[]> => {
+const readAllTags = async (locale: Locale): Promise<TagView[]> => {
   const payload = await getPayload({ config })
 
   const result = await payload.find({
     collection: 'tags',
+    locale,
     sort: 'name',
     limit: 200,
     // Only the name is displayed: the relations are not needed here.

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -102,7 +102,7 @@ export interface Config {
   db: {
     defaultIDType: number
   }
-  fallbackLocale: null
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('fr' | 'en') | ('fr' | 'en')[]
   globals: {
     'site-identity': SiteIdentity
     availability: Availability
@@ -115,7 +115,7 @@ export interface Config {
     profile: ProfileSelect<false> | ProfileSelect<true>
     'assistant-settings': AssistantSettingsSelect<false> | AssistantSettingsSelect<true>
   }
-  locale: null
+  locale: 'fr' | 'en'
   widgets: {
     collections: CollectionsWidget
   }

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -51,7 +51,11 @@
   par `createMiddleware` dans `src/proxy.ts`, catalogues ICU dans `messages/*.json`,
   sélecteur de langue dans l'en-tête, sitemap et `hreflang` par locale, assistant
   qui répond dans la langue de la conversation.
-  Reste à faire : localisation du contenu éditorial Payload (voir #74).
+- Contenu éditorial localisé dans Payload (issue #74, 2e lot) : `localization`
+  activée (`fr` par défaut, `fallback: true`), champs de prose marqués
+  `localized: true`. `/admin` affiche un sélecteur de langue par document. Les
+  lectures serveur reçoivent la locale et le cache est clé par langue. Reste à
+  faire, et c'est éditorial : écrire les traductions anglaises du contenu réel.
 - Code hérité de l'ère Express retiré : `lib/api.ts`, `lib/query-client.ts`,
   `providers.tsx`, `data/portfolio.ts`, pages `/liens` et `/demo`. React Query,
   Axios et quatre autres dépendances désinstallées.
@@ -164,6 +168,37 @@
 - Les états de filtre (`veille`, `outils-ia`) utilisent une sentinelle stable
   (`' all'`, `'all'`), pas le libellé traduit : changer de langue ne doit
   pas réinitialiser le filtre.
+- **Localisation Payload : ce qui est traduit et ce qui ne l'est pas.** Sont
+  `localized` la prose écrite à la main (headline, bio, principes, rôle, contexte
+  et réalisations d'expérience, descriptions de projets et d'outils, questions et
+  réponses `ai-knowledge`, avis de conservation). Ne le sont pas, volontairement :
+  les noms propres (entreprise, titre de projet, nom d'outil), les données
+  factuelles (URL, email, dates, hébergeur, éditeur légal), les technologies, les
+  snippets de commandes — un `pnpm install` ne se traduit pas — et la veille,
+  dont les titres viennent de la source. Les tags restent non localisés : ce sont
+  des termes techniques, le gain ne vaut pas la charge de saisie.
+- `defaultLocale: 'fr'` côté Payload alors que le site sert l'anglais par défaut.
+  Ce n'est pas une incohérence : l'un dit quelle langue voit le visiteur, l'autre
+  quelle langue sert de repli quand une traduction manque. Le contenu existant
+  étant français, c'est lui la source.
+- Le type `Locale` de Payload déclare **`code`**, pas `value` — alors que le
+  commentaire d'exemple sur `LocalizationConfigWithLabels` montre `value`. Se
+  tromper de clé produit un enum `_locales` vide et fait échouer `migrate:create`
+  sur un message obscur.
+- **`migrate:create` ne migre pas les données.** La migration générée pour la
+  localisation créait les tables `_locales` puis supprimait les colonnes
+  d'origine, sans rien recopier : l'appliquer telle quelle vidait tout le contenu.
+  Les `INSERT … SELECT` vers la locale `fr` ont été ajoutés à la main avant les
+  `DROP`, et le `down()` réécrit pour rajouter les colonnes en nullable, recopier,
+  puis remettre `NOT NULL` — sinon le rollback échoue sur une table non vide.
+  Vérifié dans les deux sens sur une base peuplée.
+- **Invalidation : purger le chemin ne suffit plus.** Les lectures sont en
+  `revalidate: false` et existent désormais une fois par langue ; régénérer le
+  HTML seul le reconstruit à partir de l'entrée périmée, et avec le repli actif
+  une valeur anglaise fraîchement saisie continuait d'afficher du français.
+  `purge` fait donc les deux : `revalidateTag(tag, { expire: 0 })` puis
+  `revalidatePath`. Le profil par défaut de `revalidateTag` ne fait que marquer
+  périmé et resservirait l'ancienne valeur une fois de plus.
 - Prettier et ESLint doivent être lancés depuis le workspace
   (`pnpm --filter @portfolio/frontend exec …`), pas depuis la racine.
 - Un écran `500` sur toutes les routes `/api/*` et `/admin` après plusieurs


### PR DESCRIPTION
## Summary

The interface became bilingual in #75, but everything edited from `/admin` stayed French: an English visitor read English navigation above a French bio and French project descriptions. Payload's own localization now covers that content, and the English translations ship with the seed.

## Related issue(s)

Closes #74

## Type of change

- [x] New feature (phase: 3)
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Chore / Tooling / Config
- [ ] Documentation only

## Domain

- **Phase**: phase: 3
- **Domain**: domain: backend, domain: database

## Technical checklist

- [x] Code follows `CLAUDE.md` conventions (naming, patterns)
- [x] Shared types in `packages/shared` (never duplicated) — content types come from the regenerated `payload-types.ts`
- [x] `pnpm type-check` passes without error
- [x] `pnpm lint` passes without error
- [x] No forgotten `console.log`
- [x] Manually tested (described below)

## What changed

**Payload** — `localization` enabled with French as `defaultLocale` and `fallback: true`. The admin gains a language switcher per document; a field with no English value yet serves the French one, so nothing is ever blank while translation is in progress.

French is the default locale even though the site serves English first. The two settings answer different questions — which language a visitor sees, versus which language stands in when a translation is missing — and the existing content is French, so it is the source.

**Which fields** — only prose: headline, bio, principles, skill-group labels, experience role/context/achievements, project and tool descriptions, `ai-knowledge` question/answer, the visitor-facing assistant messages, job title, location, and the data-policy notice. Proper nouns (company, project, tool names), factual data (URLs, email, dates, host, legal publisher), technologies and command snippets stay single-valued — a `pnpm install` does not get translated. Bookmarks keep their source-language titles.

**Reads** — every reader takes the locale, and the cache is keyed by it.

**Translations** — the seed now writes each document twice, French then English. Translated: the headline, the bio, the four principles, the skill-group labels, the three project descriptions, and `location` ("Île-de-France, Paris" names the region first, which reads backwards in English).

## Manual test performed

Against a populated database and a clean production build:

| Check | Result |
|---|---|
| Migration up | French content intact — headline, 3 project descriptions, 5 experiences, identity |
| Migration down | Same content restored into the original columns |
| Both locales coexist | Verified per field, arrays included |
| Write isolation | Writing English alone updates `/en`, leaves `/fr` untouched |
| Clean build | `/fr/a-propos` French, `/en/a-propos` English |
| Static rendering | 16 pages prerendered, 8 per language |
| Tests | 188 passing (19 files) |

## Notes for review

**⚠️ Back up Supabase before applying the migration.** It moves columns into `_locales` tables. It was verified to preserve data in both directions here, but this is not an operation to replay.

**Four failure modes this uncovered, all silent:**

1. **`migrate:create` does not migrate data.** The generated migration created the `_locales` tables and dropped the source columns without copying anything — applying it as-is would have emptied every localized field. The `INSERT … SELECT` into the French locale is added before the drops.

2. **The generated `down()` could not run.** It added NOT NULL columns outright, which fails on a table that already holds rows, and restored nothing. Rewritten to add them nullable, copy back, then reinstate NOT NULL.

3. **Purging the path stopped being enough.** The cached reads carry `revalidate: false` and now exist once per language, so replacing the HTML re-rendered the page against the stale entry: a freshly written English value kept rendering French. `purge` now drops the data cache too, with `expire: 0` — the default profile only marks it stale and would serve the old value once more.

4. **The seed was not idempotent for projects**, and had not been since the Open Graph hook started canonicalizing URLs on save. The stored value carries a trailing slash the literal seed value does not, so the lookup matched nothing and a second run tried to create a duplicate. Pre-existing, fixed here since the seed had to run twice.

Also worth knowing: the English pass reads each document back before writing, to reuse the array row ids. Sending an array without them makes Payload treat it as a new set of rows and drops the French values with the old ones — the skill labels and principles would have been silently lost.

**One editorial decision left to Adem:** the career path is already written in English, so its values serve both languages and `/fr` shows English experience entries. Writing French versions is a content call, not a technical gap.

**Not merged.** Waiting on Adem's manual merge, per the project rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgdW78pAu3v1RzvYXSHUJZ)_